### PR TITLE
Detect country by phone number

### DIFF
--- a/src/country.rs
+++ b/src/country.rs
@@ -23,6 +23,8 @@ pub struct Code {
 
 	/// The source from which the country code is derived.
 	pub(crate) source: Source,
+
+	pub(crate) alpha2: Result<Country, ()>,
 }
 
 /// The source from which the country code is derived. This is not set in the
@@ -65,6 +67,10 @@ impl Code {
 
 	pub fn source(&self) -> Source {
 		self.source
+	}
+
+	pub fn alpha2(&self) -> Result<Country, ()> {
+		self.alpha2
 	}
 }
 
@@ -321,6 +327,14 @@ pub enum Country {
 	ZA,
 	ZM,
 	ZW,
+	None,
+}
+
+impl Default for Country {
+	fn default() -> Self {
+		Country::None
+	}
+
 }
 
 impl str::FromStr for Country {
@@ -824,6 +838,7 @@ impl AsRef<str> for Country {
 			Country::ZA => "ZA",
 			Country::ZM => "ZM",
 			Country::ZW => "ZW",
+			_ 			=> "",
 		}
 	}
 }

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -179,10 +179,10 @@ impl Database {
 
 			by_id.insert(meta.id.clone(), meta.clone());
 
-			let mut by_code = by_code.entry(meta.country_code)
+			let by_code = by_code.entry(meta.country_code)
 				.or_insert_with(Vec::new);
 
-			let mut regions = regions.entry(meta.country_code)
+			let regions = regions.entry(meta.country_code)
 				.or_insert_with(Vec::new);
 
 			if meta.main_country_for_code {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,8 +20,6 @@ pub use std::str::FromStr;
 use extension::Extension;
 use carrier::Carrier;
 use consts;
-use validator::{self, Validation};
-use phone_number::Type;
 use error::{self, Result};
 
 pub mod helper;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -209,5 +209,69 @@ mod test {
 			extension: None,
 			carrier:   Some("12".into()),
 		}, parser::parse(Some(Country::BR), "012 3121286979").unwrap());
+
+		assert_eq!(PhoneNumber {
+			country: Code {
+				code:   61,
+				source: Source::Plus,
+				alpha2: Ok(Country::AU),
+			},
+
+			national: NationalNumber {
+				value: 406823897,
+				zeros: 0,
+			},
+
+			extension: None,
+			carrier:   None,
+		}, parser::parse(Some(Country::None), "+61406823897").unwrap());
+
+		assert_eq!(PhoneNumber {
+			country: Code {
+				code:   34,
+				source: Source::Plus,
+				alpha2: Ok(Country::ES),
+			},
+
+			national: NationalNumber {
+				value: 666777888,
+				zeros: 0,
+			},
+
+			extension: None,
+			carrier:   None,
+		}, parser::parse(Some(Country::None), "+34666777888").unwrap());
+
+		assert_eq!(PhoneNumber {
+			country: Code {
+				code:   1,
+				source: Source::Plus,
+				alpha2: Ok(Country::KY),
+			},
+
+			national: NationalNumber {
+				value: 3459492311,
+				zeros: 0,
+			},
+
+			extension: None,
+			carrier:   None,
+		}, parser::parse(Some(Country::None), "+13459492311").unwrap());
+
+		assert_eq!(PhoneNumber {
+			country: Code {
+				code:   1,
+				source: Source::Plus,
+				alpha2: Ok(Country::CA),
+			},
+
+			national: NationalNumber {
+				value: 6137827274,
+				zeros: 0,
+			},
+
+			extension: None,
+			carrier:   None,
+		}, parser::parse(Some(Country::None), "+16137827274").unwrap());
 	}
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -89,6 +89,7 @@ mod test {
 			country: Code {
 				code:   64,
 				source: Source::Default,
+				alpha2: Ok(Country::NZ),
 			},
 
 			national: NationalNumber {
@@ -131,6 +132,7 @@ mod test {
 			country: Code {
 				code:   64,
 				source: Source::Number,
+				alpha2: Ok(Country::NZ),
 			},
 
 			national: NationalNumber {
@@ -148,6 +150,7 @@ mod test {
 			country: Code {
 				code:   49,
 				source: Source::Default,
+				alpha2: Ok(Country::DE),
 			},
 
 			national: NationalNumber {
@@ -163,6 +166,7 @@ mod test {
 			country: Code {
 				code:   81,
 				source: Source::Plus,
+				alpha2: Ok(Country::JP),
 			},
 
 			national: NationalNumber {
@@ -178,6 +182,7 @@ mod test {
 			country: Code {
 				code:   64,
 				source: Source::Default,
+				alpha2: Ok(Country::NZ),
 			},
 
 			national: NationalNumber {
@@ -193,6 +198,7 @@ mod test {
 			country: Code {
 				code:   55,
 				source: Source::Default,
+				alpha2: Ok(Country::BR),
 			},
 
 			national: NationalNumber {


### PR DESCRIPTION
Hi,

this is just an initial implementation that detects country iso alpha2.

I'm new to Rust and so there are many code improvements to do. I've also detected that Australian numbers are not properly detected but I don't really know why, run tests to see. 😢 

The approach I take is to get all Metadata matching a given country code and lookup for leading_digits regex if present.

Thanks!