### PR TITLE
enable the verbose-errors feature for the nom crate in order to work with bindgen-dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ failure     = "0.1"
 quick-xml   = "0.12"
 itertools   = "0.7"
 either      = "1.0"
-nom         = "3.2"
+nom         = {version="3.2", features=["verbose-errors"]}
 
 serde        = "1.0"
 serde_derive = "1.0"

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -68,7 +68,7 @@ pub fn extract(value: &str) -> IResult<&str, &str> {
 		(&value[index.start() ..], index.start())
 	}
 	else {
-		return IResult::Error(nom::ErrorKind::RegexpMatch);
+		return IResult::Error(nom::Err::Code(nom::ErrorKind::RegexpMatch));
 	};
 
 	if let Some(trailing) = consts::UNWANTED_END_CHARS.find(result) {
@@ -80,7 +80,7 @@ pub fn extract(value: &str) -> IResult<&str, &str> {
 	}
 
 	if result.is_empty() {
-		IResult::Error(nom::ErrorKind::RegexpMatch)
+		IResult::Error(nom::Err::Code(nom::ErrorKind::RegexpMatch))
 	}
 	else {
 		IResult::Done(&value[start + result.len() ..], result)

--- a/src/parser/rfc3966.rs
+++ b/src/parser/rfc3966.rs
@@ -76,7 +76,7 @@ fn check(i: &str) -> IResult<&str, ()> {
 		IResult::Done(i, ())
 	}
 	else {
-		IResult::Error(nom::ErrorKind::Tag)
+		IResult::Error(nom::Err::Code(nom::ErrorKind::Tag))
 	}
 }
 


### PR DESCRIPTION
To solve #7 