### PR TITLE
Returning `error::Parse` in `parse` function 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -82,3 +82,9 @@ pub enum Parse {
 	#[fail(display = "the number is too long")]
 	TooLong,
 }
+
+impl From<std::num::ParseIntError> for Parse {
+    fn from(_item: std::num::ParseIntError) -> Parse {
+        Parse::NoNumber
+    }
+}

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -17,7 +17,6 @@ use nom::{self, AsChar, IResult, error::{make_error, ErrorKind}, character::comp
 
 use fnv::FnvHashMap;
 use regex_cache::CachedRegex;
-use failure::Error;
 
 use crate::error;
 use crate::consts;
@@ -134,7 +133,7 @@ pub fn extract(value: &str) -> IResult<&str, &str> {
 }
 
 /// Parse and insert the proper country code.
-pub fn country_code<'a>(database: &Database, country: Option<country::Id>, mut number: Number<'a>) -> Result<Number<'a>, Error> {
+pub fn country_code<'a>(database: &Database, country: Option<country::Id>, mut number: Number<'a>) -> Result<Number<'a>, error::Parse> {
 	let idd = country
 		.and_then(|c| database.by_id(c.as_ref()))
 		.and_then(|m| m.international_prefix.as_ref());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use failure::Error;
-
 use crate::metadata::{DATABASE, Database};
 use crate::phone_number::{PhoneNumber, Type};
 use crate::national_number::NationalNumber;
@@ -33,12 +31,12 @@ pub mod rfc3966;
 pub mod natural;
 
 /// Parse a phone number.
-pub fn parse<S: AsRef<str>>(country: Option<country::Id>, string: S) -> Result<PhoneNumber, Error> {
+pub fn parse<S: AsRef<str>>(country: Option<country::Id>, string: S) -> Result<PhoneNumber, error::Parse> {
 	parse_with(&*DATABASE, country, string)
 }
 
 /// Parse a phone number using a specific `Database`.
-pub fn parse_with<S: AsRef<str>>(database: &Database, country: Option<country::Id>, string: S) -> Result<PhoneNumber, Error> {
+pub fn parse_with<S: AsRef<str>>(database: &Database, country: Option<country::Id>, string: S) -> Result<PhoneNumber, error::Parse> {
 	fn phone_number(i: &str) -> IResult<&str, helper::Number> {
 		parse! { i => alt((rfc3966::phone_number, natural::phone_number)) }
 	}

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -16,7 +16,6 @@ use std::fmt;
 use std::str::FromStr;
 use std::ops::Deref;
 use either::*;
-use failure::Error;
 
 use crate::country;
 use crate::national_number::NationalNumber;
@@ -26,6 +25,7 @@ use crate::metadata::{DATABASE, Database, Metadata};
 use crate::parser;
 use crate::formatter;
 use crate::validator;
+use crate::error;
 
 /// A phone number.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
@@ -140,9 +140,9 @@ pub enum Type {
 }
 
 impl FromStr for PhoneNumber {
-	type Err = Error;
+	type Err = error::Parse;
 
-	fn from_str(s: &str) -> Result<Self, Error> {
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		parser::parse(None, s)
 	}
 }


### PR DESCRIPTION
Solves #17 