### PR TITLE
Use the varint bincode encoding

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate bincode;
 
+use bincode::Options;
+
 #[path = "src/metadata/loader.rs"]
 mod loader;
 
@@ -28,6 +30,6 @@ fn main() {
 		&Path::new(&env::var("OUT_DIR").unwrap()).join("database.bin"))
 			.expect("could not create database file"));
 
-	bincode::serialize_into(&mut out, &metadata)
+	bincode::options().with_varint_encoding().serialize_into(&mut out, &metadata)
 		.expect("failed to serialize database");
 }

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -19,6 +19,7 @@ use std::borrow::Borrow;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
+use bincode::Options;
 use fnv::FnvHashMap;
 use regex_cache::{RegexCache, CachedRegex, CachedRegexBuilder};
 use bincode;
@@ -31,7 +32,8 @@ const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin")
 lazy_static! {
 	/// The Google provided metadata database, used as default.
 	pub static ref DEFAULT: Database =
-		Database::from(bincode::deserialize(DATABASE).unwrap()).unwrap();
+		Database::from(bincode::options()
+		.with_varint_encoding().deserialize(DATABASE).unwrap()).unwrap();
 }
 
 /// Representation of a database of metadata for phone number.


### PR DESCRIPTION
This change makes the database.bin file about 100k smaller on a x86_64 machine:

Before:
`580953 Oct  9 17:00 ./target/release/build/phonenumber-5fea785186873c26/out/database.bin`

After
`482133 Oct  9 17:22 ./target/release/build/phonenumber-5fea785186873c26/out/database.bin`