### PR TITLE
Improve Metadata initialization time, add benchmarking, check regexps during build & general housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,29 +12,29 @@ keywords    = ["phonenumber", "phone", "number", "parser", "formatter"]
 readme = "README.md"
 
 [dependencies]
-regex       = "1.3.9"
+regex       = "1.4"
 regex-syntax = "0.6"
 regex-cache = "~0.2.1"
-lazy_static = "1.4.0"
+lazy_static = "1.4"
 fnv         = "1.0"
-thiserror   = "1.0.20"
-quick-xml   = "0.18.1"
-itertools   = "0.9.0"
-either      = "1.6.0"
-nom         = "5"
+thiserror   = "~1.0.21"
+quick-xml   = "0.19"
+itertools   = "0.9"
+either      = "1.6"
+nom         = "5.1"
 
 serde        = "1.0"
 serde_derive = "1.0"
-bincode      = "1.3.1"
+bincode      = "1.3"
 
 [build-dependencies]
-quick-xml    = "0.18.1"
-thiserror    = "1.0.20"
-regex        = "1.3.9"
+quick-xml    = "0.19"
+thiserror    = "~1.0.21"
+regex        = "1.4"
 regex-syntax = "0.6"
 serde        = "1.0"
 serde_derive = "1.0"
-bincode      = "1.3.1"
+bincode      = "1.3"
 
 [dev-dependencies]
 doc-comment  = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name    = "phonenumber"
 version = "0.3.2+8.12.9"
 edition = "2018"
 
-authors = ["meh. <meh@1aim.com>"]
+authors = ["meh. <meh@1aim.com>", "Philipp Korber <philipp@korber.dev>", "Yann Leretaille <yann@leretaille.com"]
 license = "Apache-2.0"
 
 description = "Library for parsing, formatting and validating international phone numbers."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "phonenumber"
-version = "0.3.1+8.12.9"
+version = "0.3.2+8.12.9"
 edition = "2018"
 
 authors = ["meh. <meh@1aim.com>"]
@@ -13,7 +13,8 @@ readme = "README.md"
 
 [dependencies]
 regex       = "1.3.9"
-regex-cache = { path = "../rust-regex-cache" }
+regex-syntax = "0.6"
+regex-cache = "~0.2.1"
 lazy_static = "1.4.0"
 fnv         = "1.0"
 thiserror   = "1.0.20"
@@ -30,6 +31,7 @@ bincode      = "1.3.1"
 quick-xml    = "0.18.1"
 thiserror    = "1.0.20"
 regex        = "1.3.9"
+regex-syntax = "0.6"
 serde        = "1.0"
 serde_derive = "1.0"
 bincode      = "1.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 regex       = "1.3.9"
-regex-cache = "0.2"
+regex-cache = { path = "../rust-regex-cache" }
 lazy_static = "1.4.0"
 fnv         = "1.0"
 thiserror   = "1.0.20"
@@ -36,3 +36,8 @@ bincode      = "1.3.1"
 
 [dev-dependencies]
 doc-comment  = "0.3"
+criterion = "0.3"
+
+[[bench]]
+name = "init"
+harness = false

--- a/benches/init.rs
+++ b/benches/init.rs
@@ -1,0 +1,42 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+
+
+use phonenumber::metadata::{Database};
+use phonenumber::metadata::loader;
+use phonenumber::PhoneNumber;
+use phonenumber::parser;
+use bincode::Options;
+
+const DATABASE_BINFILE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
+
+fn bincode_deserialize_database(db_raw: &[u8]) -> Vec<loader::Metadata> {
+    bincode::options()
+		.with_varint_encoding().deserialize(db_raw).unwrap()
+}
+
+fn parse_database(db_decoded: Vec<loader::Metadata>) -> Database {
+    Database::from(db_decoded).unwrap()
+}
+
+fn first_query(db: &Database) -> PhoneNumber {
+    parser::parse_with(db, None, "+16137827274").unwrap()
+}
+
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("init");
+    group.sampling_mode(SamplingMode::Auto);
+    group.sample_size(50);
+
+    group.bench_function("deserialize binencoded database", |b| b.iter(|| bincode_deserialize_database(black_box(DATABASE_BINFILE))));
+
+    let db_decoded = bincode_deserialize_database(DATABASE_BINFILE);
+    group.bench_function("parse database", |b| b.iter(|| parse_database(black_box(db_decoded.to_vec()))));
+
+    let db = parse_database(db_decoded.to_vec());
+    group.bench_function("first query", |b| { db.cache().lock().unwrap().clear(); b.iter(|| first_query(black_box(&db))) });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/init.rs
+++ b/benches/init.rs
@@ -15,7 +15,7 @@ fn bincode_deserialize_database(db_raw: &[u8]) -> Vec<loader::Metadata> {
 }
 
 fn parse_database(db_decoded: Vec<loader::Metadata>) -> Database {
-    Database::from(db_decoded).unwrap()
+    Database::from(db_decoded, false).unwrap()
 }
 
 fn first_query(db: &Database) -> PhoneNumber {
@@ -31,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("deserialize binencoded database", |b| b.iter(|| bincode_deserialize_database(black_box(DATABASE_BINFILE))));
 
     let db_decoded = bincode_deserialize_database(DATABASE_BINFILE);
-    group.bench_function("parse database", |b| b.iter(|| parse_database(black_box(db_decoded.to_vec()))));
+    group.bench_function("parse database (unchecked)", |b| b.iter(|| parse_database(black_box(db_decoded.to_vec()))));
 
     let db = parse_database(db_decoded.to_vec());
     group.bench_function("first query", |b| { db.cache().lock().unwrap().clear(); b.iter(|| first_query(black_box(&db))) });

--- a/benches/init.rs
+++ b/benches/init.rs
@@ -10,32 +10,32 @@ use bincode::Options;
 const DATABASE_BINFILE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 
 fn bincode_deserialize_database(db_raw: &[u8]) -> Vec<loader::Metadata> {
-    bincode::options()
+	bincode::options()
 		.with_varint_encoding().deserialize(db_raw).unwrap()
 }
 
 fn parse_database(db_decoded: Vec<loader::Metadata>) -> Database {
-    Database::from(db_decoded, false).unwrap()
+	Database::from(db_decoded, false).unwrap()
 }
 
 fn first_query(db: &Database) -> PhoneNumber {
-    parser::parse_with(db, None, "+16137827274").unwrap()
+	parser::parse_with(db, None, "+16137827274").unwrap()
 }
 
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("init");
-    group.sampling_mode(SamplingMode::Auto);
-    group.sample_size(50);
+	let mut group = c.benchmark_group("init");
+	group.sampling_mode(SamplingMode::Auto);
+	group.sample_size(50);
 
-    group.bench_function("deserialize binencoded database", |b| b.iter(|| bincode_deserialize_database(black_box(DATABASE_BINFILE))));
+	group.bench_function("deserialize binencoded database", |b| b.iter(|| bincode_deserialize_database(black_box(DATABASE_BINFILE))));
 
-    let db_decoded = bincode_deserialize_database(DATABASE_BINFILE);
-    group.bench_function("parse database (unchecked)", |b| b.iter(|| parse_database(black_box(db_decoded.to_vec()))));
+	let db_decoded = bincode_deserialize_database(DATABASE_BINFILE);
+	group.bench_function("parse database (unchecked)", |b| b.iter(|| parse_database(black_box(db_decoded.to_vec()))));
 
-    let db = parse_database(db_decoded.to_vec());
-    group.bench_function("first query", |b| { db.cache().lock().unwrap().clear(); b.iter(|| first_query(black_box(&db))) });
-    group.finish();
+	let db = parse_database(db_decoded.to_vec());
+	group.bench_function("first query", |b| { db.cache().lock().unwrap().clear(); b.iter(|| first_query(black_box(&db))) });
+	group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ use std::env;
 
 extern crate thiserror;
 extern crate regex;
+extern crate regex_syntax;
 extern crate quick_xml as xml;
 
 extern crate serde;
@@ -21,6 +22,8 @@ mod loader;
 mod error;
 
 fn main() {
+	println!("cargo:rerun-if-changed=assets/PhoneNumberMetadata.xml");
+
 	let metadata = loader::load(BufReader::new(
 		File::open("assets/PhoneNumberMetadata.xml")
 			.expect("could not open metadata file")))

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,8 +26,8 @@ pub enum Metadata {
 	MismatchedTag(String),
 
 	/// A required value was missing.
-    #[error("{phase}: missing value: {name:?}")]
-    #[allow(unused)] // This is unused in the build script
+	#[error("{phase}: missing value: {name:?}")]
+	#[allow(unused)] // This is unused in the build script
 	MissingValue {
 		phase: String,
 		name:  String,
@@ -61,38 +61,38 @@ pub enum Metadata {
 pub enum Parse {
 	/// This generally indicates the string passed in had less than 3 digits in
 	/// it.
-    #[error("not a number")]
-    #[allow(unused)] // This is unused in the build script
+	#[error("not a number")]
+	#[allow(unused)] // This is unused in the build script
 	NoNumber,
 
 	/// The country code supplied did not belong to a supported country or
 	/// non-geographical entity.
-    #[error("invalid country code")]
-    #[allow(unused)] // This is unused in the build script
+	#[error("invalid country code")]
+	#[allow(unused)] // This is unused in the build script
 	InvalidCountryCode,
 
 	/// This indicates the string started with an international dialing prefix,
 	/// but after this was stripped from the number, had less digits than any
 	/// valid phone number (including country code) could have.
-    #[error("the number is too short after IDD")]
-    #[allow(unused)] // This is unused in the build script
+	#[error("the number is too short after IDD")]
+	#[allow(unused)] // This is unused in the build script
 	TooShortAfterIdd,
 
 	/// This indicates the string, after any country code has been stripped, had
 	/// less digits than any valid phone number could have.
-    #[error("the number is too short after the country code")]
-    #[allow(unused)] // This is unused in the build script
+	#[error("the number is too short after the country code")]
+	#[allow(unused)] // This is unused in the build script
 	TooShortNsn,
 
 	/// This indicates the string had more digits than any valid phone number
 	/// could have.
-    #[error("the number is too long")]
-    #[allow(unused)] // This is unused in the build script
-    TooLong,
+	#[error("the number is too long")]
+	#[allow(unused)] // This is unused in the build script
+	TooLong,
 
-    /// A integer parts of a number is malformed, normally this should be caught by the parsing regexes.
-    #[error("malformed integer part in phone number: {0}")]
-    MalformedInteger(#[from] std::num::ParseIntError),
+	/// A integer parts of a number is malformed, normally this should be caught by the parsing regexes.
+	#[error("malformed integer part in phone number: {0}")]
+	MalformedInteger(#[from] std::num::ParseIntError),
 }
 
 
@@ -100,35 +100,35 @@ pub enum Parse {
 #[derive(Error, Debug)]
 pub enum LoadMetadata {
 
-    /// Parsing XML failed, the XML is malformed.
-    #[error("Malformed Metadata XML: {0}")]
-    Xml(#[from] xml::Error),
+	/// Parsing XML failed, the XML is malformed.
+	#[error("Malformed Metadata XML: {0}")]
+	Xml(#[from] xml::Error),
 
-    /// Parsing UTF-8 string from XML failed.
-    #[error("Non UTF-8 string in Metadata XML: {0}")]
-    Utf8(#[from] std::str::Utf8Error),
+	/// Parsing UTF-8 string from XML failed.
+	#[error("Non UTF-8 string in Metadata XML: {0}")]
+	Utf8(#[from] std::str::Utf8Error),
 
-    /// Metadata Error
-    #[error("{0}")]
-    Metadata(#[from] Metadata),
+	/// Metadata Error
+	#[error("{0}")]
+	Metadata(#[from] Metadata),
 
-    /// Malformed integer in Metadata XML database
-    #[error("Malformed integer in Metadata XML: {0}")]
-    Integer(#[from] std::num::ParseIntError),
+	/// Malformed integer in Metadata XML database
+	#[error("Malformed integer in Metadata XML: {0}")]
+	Integer(#[from] std::num::ParseIntError),
 
-    /// Malformed boolean in Metadata XML database
-    #[error("Malformed boolean in Metadata XML: {0}")]
-    Bool(#[from] std::str::ParseBoolError),
+	/// Malformed boolean in Metadata XML database
+	#[error("Malformed boolean in Metadata XML: {0}")]
+	Bool(#[from] std::str::ParseBoolError),
 
-    /// I/O-Error while reading Metadata XML database
-    #[error("I/O-Error in Metadata XML: {0}")]
-    Io(#[from] std::io::Error),
+	/// I/O-Error while reading Metadata XML database
+	#[error("I/O-Error in Metadata XML: {0}")]
+	Io(#[from] std::io::Error),
 
-    /// Malformed Regex in Metadata XML database
-    #[error("Malformed Regex: {0}")]
+	/// Malformed Regex in Metadata XML database
+	#[error("Malformed Regex: {0}")]
 	Regex(#[from] regex::Error),
 	
 	#[error("Malformed Regex: {0}")]
-    RegexSyntax(#[from] regex_syntax::Error),
+	RegexSyntax(#[from] regex_syntax::Error),
 
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,9 @@ pub enum LoadMetadata {
 
     /// Malformed Regex in Metadata XML database
     #[error("Malformed Regex: {0}")]
-    Regex(#[from] regex::Error),
+	Regex(#[from] regex::Error),
+	
+	#[error("Malformed Regex: {0}")]
+    RegexSyntax(#[from] regex_syntax::Error),
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate nom;
 
 extern crate regex;
 extern crate regex_cache;
+extern crate regex_syntax;
 extern crate fnv;
 extern crate quick_xml as xml;
 extern crate itertools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub use crate::carrier::Carrier;
 mod phone_number;
 pub use crate::phone_number::{PhoneNumber, Type};
 
-mod parser;
+pub mod parser;
 pub use crate::parser::{parse, parse_with};
 
 mod formatter;

--- a/src/metadata/loader.rs
+++ b/src/metadata/loader.rs
@@ -633,9 +633,7 @@ fn text<R: BufRead>(reader: &mut Reader<R>, name: &[u8]) -> Result<String, error
 fn text_check_regex<R: BufRead>(reader: &mut Reader<R>, name: &[u8]) -> Result<String, error::LoadMetadata> {
 	let regex_source = text(reader, name)?;
 	// check regular expression syntax
-	if let Err(err) = regex_syntax::Parser::new().parse(&regex_source) {
-		return Err(error::LoadMetadata::RegexSyntax(err));
-	}
+	check_regex(&regex_source)?;
 	Ok(regex_source)
 }
 


### PR DESCRIPTION
Please note that these changes depend on the not yet released version 0.2.1 of [regex-cache](https://github.com/1aim/rust-regex-cache/pull/2). This should fix #26 
@meh @rustonaut would be great if you guys could have a look!