### PR TITLE
Derive Ord trait for PhoneNumber struct (and its fields)

### DIFF
--- a/src/carrier.rs
+++ b/src/carrier.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::fmt;
 
 /// A phone number carrier.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, Debug)]
 pub struct Carrier(pub(crate) String);
 
 impl<T: Into<String>> From<T> for Carrier {

--- a/src/country.rs
+++ b/src/country.rs
@@ -16,7 +16,7 @@
 
 use std::str;
 
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, Debug)]
 pub struct Code {
 	/// The country code value.
 	pub(crate) value: u16,
@@ -27,7 +27,7 @@ pub struct Code {
 
 /// The source from which the country code is derived. This is not set in the
 /// general parsing method, but in the method that parses and keeps raw_input.
-#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Serialize, Deserialize, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Source {
 	/// The country code is derived based on a phone number with a leading "+",

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::fmt;
 
 /// A phone number extension.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, Debug)]
 pub struct Extension(pub(crate) String);
 
 impl<T: Into<String>> From<T> for Extension {

--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 /// The national number part of a phone number.
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, Debug)]
 pub struct NationalNumber {
 	pub(crate) value: u64,
 

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -28,7 +28,7 @@ use crate::validator;
 use crate::error;
 
 /// A phone number.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, Debug)]
 pub struct PhoneNumber {
 	/// The country calling code for this number, as defined by the International
 	/// Telecommunication Union (ITU). For example, this would be 1 for NANPA


### PR DESCRIPTION
Making it possible to compare `PhoneNumber` for a sort-order.