### PR TITLE
add a concete Err type for trait impl FromStr for Id

### DIFF
--- a/src/country.rs
+++ b/src/country.rs
@@ -15,6 +15,7 @@
 //! Country related types.
 
 use std::str;
+use crate::error;
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub struct Code {
@@ -329,9 +330,9 @@ pub enum Id {
 pub use self::Id::*;
 
 impl str::FromStr for Id {
-	type Err = ();
+	type Err = error::Parse;
 
-	fn from_str(value: &str) -> Result<Id, ()> {
+	fn from_str(value: &str) -> Result<Id, Self::Err> {
 		match value {
 			"AC" => Ok(Id::AC),
 			"AD" => Ok(Id::AD),
@@ -578,7 +579,7 @@ impl str::FromStr for Id {
 			"ZA" => Ok(Id::ZA),
 			"ZM" => Ok(Id::ZM),
 			"ZW" => Ok(Id::ZW),
-			_    => Err(()),
+			_    => Err(error::Parse::InvalidCountryCode),
 		}
 	}
 }


### PR DESCRIPTION
Hi!

I made this PR because to provide a specific error type as err type for the FromStr trait implementation for the enum Id.

Thank you!