### PR TITLE
Fit NationalNumber in 64 bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ doc-comment = "0.3"
 rstest = ">= 0.13, <=0.18"
 rstest_reuse = "0.6"
 anyhow = "1"
+criterion = "0.5"
+
+[[bench]]
+name = "parsing"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ doc-comment = "0.3"
 rstest = ">= 0.13, <=0.18"
 rstest_reuse = "0.6"
 anyhow = "1"
-criterion = "0.5"
+criterion = ">=0.4, <=0.5"
 
 [[bench]]
 name = "parsing"

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,0 +1,29 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let cases = [
+        "+80012340000",
+        "+61406823897",
+        "+611900123456",
+        "+32474091150",
+        "+34666777888",
+        "+34612345678",
+        "+441212345678",
+        "+13459492311",
+        "+16137827274",
+        "+1 520 878 2491",
+        "+1-520-878-2491",
+    ];
+
+    for case in cases {
+        c.bench_with_input(BenchmarkId::new("parse", case), &case, |b, case| {
+            b.iter(|| {
+                let pn = black_box(case);
+                phonenumber::parse(None, pn)
+            })
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -84,10 +84,10 @@ pub fn parse_with<S: AsRef<str>>(
             source: number.country,
         },
 
-        national: NationalNumber {
-            value: number.national.parse()?,
-            zeros: number.national.chars().take_while(|&c| c == '0').count() as u8,
-        },
+        national: NationalNumber::new(
+            number.national.parse()?,
+            number.national.chars().take_while(|&c| c == '0').count() as u8,
+        ),
 
         extension: number.extension.map(|s| Extension(s.into_owned())),
         carrier: number.carrier.map(|s| Carrier(s.into_owned())),
@@ -109,10 +109,7 @@ mod test {
                 source: country::Source::Default,
             },
 
-            national: NationalNumber {
-                value: 33316005,
-                zeros: 0,
-            },
+            national: NationalNumber::new(33316005, 0),
 
             extension: None,
             carrier: None,
@@ -200,10 +197,7 @@ mod test {
                 source: country::Source::Number,
             },
 
-            national: NationalNumber {
-                value: 64123456,
-                zeros: 0,
-            },
+            national: NationalNumber::new(64123456, 0),
 
             extension: None,
             carrier: None,
@@ -221,10 +215,7 @@ mod test {
                     source: country::Source::Default,
                 },
 
-                national: NationalNumber {
-                    value: 30123456,
-                    zeros: 0,
-                },
+                national: NationalNumber::new(30123456, 0),
 
                 extension: None,
                 carrier: None,
@@ -239,10 +230,7 @@ mod test {
                     source: country::Source::Plus,
                 },
 
-                national: NationalNumber {
-                    value: 2345,
-                    zeros: 0,
-                },
+                national: NationalNumber::new(2345, 0,),
 
                 extension: None,
                 carrier: None,
@@ -257,10 +245,7 @@ mod test {
                     source: country::Source::Default,
                 },
 
-                national: NationalNumber {
-                    value: 12,
-                    zeros: 0,
-                },
+                national: NationalNumber::new(12, 0,),
 
                 extension: None,
                 carrier: None,
@@ -275,10 +260,7 @@ mod test {
                     source: country::Source::Default,
                 },
 
-                national: NationalNumber {
-                    value: 3121286979,
-                    zeros: 0,
-                },
+                national: NationalNumber::new(3121286979, 0),
 
                 extension: None,
                 carrier: Some("12".into()),


### PR DESCRIPTION
This reduces the stack size of a PhoneNumber from 576 to 512 bits, by compressing the zeroes prefix into the value of the NationalNumber. The external API stays the same, but we win a precious 8 bytes because of alignment. If you don't have Carriers or Extensions, this is all on the stack too. Pretty cool.

We might be able to win 16 bits in `Code` too, but that'll need more trickery that might make it slightly less Rusty.

I got nerd sniped. Will spin up some benchmarks to make sure this is not too bad in terms of performance.