### PR TITLE
Add more tests and run code coverage analysis

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,1 @@
+output-path: ./coverage.xml

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+github_checks:
+  annotations: false
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,27 @@ concurrency:
 
 jobs:
   build_and_test:
-    name: cargo build
+    name: cargo test
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["stable", "beta"]
+        coverage: [false]
+        include:
+          - toolchain: "nightly"
+            coverage: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      
-      - name: Setup Rust toolchain
-        run: rustup install stable
-      
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
       - name: Configure CI cache
         uses: Swatinem/rust-cache@v2
 
@@ -34,7 +44,7 @@ jobs:
         with:
           command: build
           args: --all-targets
-      
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -43,9 +53,11 @@ jobs:
 
       - name: Generate code coverage
         uses: actions-rs/grcov@v0.1
+        if: ${{ matrix.coverage }}
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3
+        if: ${{ matrix.coverage }}
 
   rustfmt:
     name: rustfmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
           command: test
           args: --all-targets
 
+      - name: Generate code coverage
+        uses: actions-rs/grcov@v0.1
+
+      - name: Upload coverage reports to Codecov with GitHub Action
+        uses: codecov/codecov-action@v3
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,21 @@ jobs:
 
       - name: Run tests
         uses: actions-rs/cargo@v1
+        if: ${{ !matrix.coverage }}
         with:
           command: test
           args: --all-targets --no-fail-fast
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.coverage }}
+        with:
+          command: test
+          args: --all-targets --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
       - name: Generate code coverage
         uses: actions-rs/grcov@v0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-targets
+          args: --all-targets --no-fail-fast
 
       - name: Generate code coverage
         uses: actions-rs/grcov@v0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 doc-comment = "0.3"
+rstest = "0.17"
+rstest_reuse = "0.5"
+anyhow = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@ extern crate bincode;
 extern crate doc_comment;
 
 #[cfg(test)]
+use rstest_reuse;
+
+#[cfg(test)]
 doctest!("../README.md");
 
 /// Errors for various parts of the crate.

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -294,9 +294,14 @@ mod test {
         };
 
         let formatted = number.format().mode(mode).to_string();
-        parser::parse(country_hint, &formatted).with_context(|| {
+        let parsed = parser::parse(country_hint, &formatted).with_context(|| {
             format!("parsing {number} after formatting in {mode:?} mode as {formatted}")
         })?;
+
+        // impl Eq for PhoneNumber does not consider differently parsed phone numbers to be equal.
+        // E.g., parsing 047409110 with BE country hint is the same phone number as +32474091150,
+        // but Eq considers them different.
+        assert_eq!(number, parsed);
 
         Ok(())
     }

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -284,11 +284,17 @@ mod test {
     // Format-parse roundtrip
     fn round_trip_parsing(
         #[case] number: PhoneNumber,
-        #[case] _country: country::Id,
-        #[values(Mode::International, Mode::E164)] mode: Mode,
+        #[case] country: country::Id,
+        #[values(Mode::International, Mode::E164, Mode::Rfc3966, Mode::National)] mode: Mode,
     ) -> anyhow::Result<()> {
+        let country_hint = if mode == Mode::National {
+            Some(country)
+        } else {
+            None
+        };
+
         let formatted = number.format().mode(mode).to_string();
-        parser::parse(None, &formatted).with_context(|| {
+        parser::parse(country_hint, &formatted).with_context(|| {
             format!("parsing {number} after formatting in {mode:?} mode as {formatted}")
         })?;
 

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -264,6 +264,9 @@ mod test {
     #[case(parsed("+16137827274"), CA)]
     #[case(parsed("+1 520 878 2491"), US)]
     #[case(parsed("+1-520-878-2491"), US)]
+    // Case for issues
+    // https://github.com/whisperfish/rust-phonenumber/issues/46 and
+    // https://github.com/whisperfish/rust-phonenumber/issues/47
     // #[case(parsed("+1 520-878-2491"), US)]
     fn phone_numbers(#[case] number: PhoneNumber, #[case] country: country::Id) {}
 

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -244,7 +244,7 @@ impl<'a> Deref for Country<'a> {
 #[cfg(test)]
 mod test {
     use crate::country::{self, *};
-    use crate::{parser, PhoneNumber};
+    use crate::{parser, Mode, PhoneNumber};
     use anyhow::Context;
     use rstest::rstest;
     use rstest_reuse::{self, *};
@@ -275,6 +275,22 @@ mod test {
                 "Phone number {number} has no associated country code id"
             ))?
         );
+
+        Ok(())
+    }
+
+    #[apply(phone_numbers)]
+    #[ignore]
+    // Format-parse roundtrip
+    fn round_trip_parsing(
+        #[case] number: PhoneNumber,
+        #[case] _country: country::Id,
+        #[values(Mode::International, Mode::E164)] mode: Mode,
+    ) -> anyhow::Result<()> {
+        let formatted = number.format().mode(mode).to_string();
+        parser::parse(None, &formatted).with_context(|| {
+            format!("parsing {number} after formatting in {mode:?} mode as {formatted}")
+        })?;
 
         Ok(())
     }

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -264,6 +264,7 @@ mod test {
     #[case(parsed("+16137827274"), CA)]
     #[case(parsed("+1 520 878 2491"), US)]
     #[case(parsed("+1-520-878-2491"), US)]
+    // #[case(parsed("+1 520-878-2491"), US)]
     fn phone_numbers(#[case] number: PhoneNumber, #[case] country: country::Id) {}
 
     #[apply(phone_numbers)]


### PR DESCRIPTION
This effectively adds reproducers for the failing #46 and #47 cases.

I have refactored the parsing tests to be more verbose when they fail and easier to dissect. This adds rstest and anyhow as dev-dependencies.