### PR TITLE
Avoid Panic when extracting country id for UIFN numbers

### DIFF
--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -250,10 +250,7 @@ mod test {
     fn country_id() {
         assert_eq!(
             None,
-            parser::parse(None, "+80012340000")
-                .unwrap()
-                .country()
-                .id()
+            parser::parse(None, "+80012340000").unwrap().country().id()
         );
 
         assert_eq!(

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -229,7 +229,7 @@ impl<'a> Country<'a> {
     }
 
     pub fn id(&self) -> Option<country::Id> {
-        self.0.metadata(&DATABASE).map(|m| m.id().parse().unwrap())
+        self.0.metadata(&DATABASE).and_then(|m| m.id().parse().ok())
     }
 }
 
@@ -248,6 +248,14 @@ mod test {
 
     #[test]
     fn country_id() {
+        assert_eq!(
+            None,
+            parser::parse(None, "+80012340000")
+                .unwrap()
+                .country()
+                .id()
+        );
+
         assert_eq!(
             country::AU,
             parser::parse(None, "+61406823897")


### PR DESCRIPTION
When trying to parse UIFN toll-free numbers, the lib panicked while retrieving the country id. This PR fixes this issue and returns None instead.

Co-authored-by: Raphael Costa <vidal.raphael@gmail.com>
