### PR TITLE
Add `PhoneNumber::number_type` method

### DIFF
--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -221,6 +221,14 @@ impl PhoneNumber {
     pub fn is_valid_with(&self, database: &Database) -> bool {
         validator::is_valid_with(database, self)
     }
+
+    /// Determine the [`Type`] of the phone number.
+    pub fn number_type(&self, database: &Database) -> Type {
+        match self.metadata(database) {
+            Some(metatdata) => validator::number_type(metatdata, &self.national.value.to_string()),
+            None => Type::Unknown,
+        }
+    }
 }
 
 impl<'a> Country<'a> {

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -252,7 +252,9 @@ impl<'a> Deref for Country<'a> {
 #[cfg(test)]
 mod test {
     use crate::country;
+    use crate::metadata::DATABASE;
     use crate::parser;
+    use crate::Type;
 
     #[test]
     fn country_id() {
@@ -290,6 +292,30 @@ mod test {
                 .country()
                 .id()
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn number_type() {
+        assert_eq!(
+            Type::FixedLine,
+            parser::parse(None, "+441212345678")
+                .unwrap()
+                .number_type(&DATABASE)
+        );
+
+        assert_eq!(
+            Type::Mobile,
+            parser::parse(None, "+34612345678")
+                .unwrap()
+                .number_type(&DATABASE)
+        );
+
+        assert_eq!(
+            Type::PremiumRate,
+            parser::parse(None, "+611900123456")
+                .unwrap()
+                .number_type(&DATABASE)
         );
     }
 }

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -225,7 +225,7 @@ impl PhoneNumber {
     /// Determine the [`Type`] of the phone number.
     pub fn number_type(&self, database: &Database) -> Type {
         match self.metadata(database) {
-            Some(metatdata) => validator::number_type(metatdata, &self.national.value.to_string()),
+            Some(metadata) => validator::number_type(metadata, &self.national.value.to_string()),
             None => Type::Unknown,
         }
     }


### PR DESCRIPTION
This PR adds a new method, `PhoneNumber::number_type`, which attempts to determine the `Type` of a phone number. I would imagine this is quite a common use-case for the library (for example, a website which accepts phone numbers for account recovery may want to check a provided number is actually a mobile number, and not a premium rate line). The actual implementation just uses the existing `validator::number_type` function, which is not currently exposed publicly. Thank you!