### PR TITLE
Bump dependencies, follow rustfmt and clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ["stable", "beta"]
+        toolchain: ["stable", "beta", "1.58.0"]
         coverage: [false]
         include:
           - toolchain: "nightly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,29 +14,29 @@ readme = "README.md"
 
 [dependencies]
 bincode = "1.3"
-either = "1.9"
+either = "1.0"
 fnv = "1.0"
-itertools = "0.11"
-nom = "7.1"
-once_cell = "1.18.0"
-quick-xml = "0.30"
+itertools = "0.2"
+nom = "7.0"
+once_cell = "1.0"
+quick-xml = "0.24"
 regex = "<=1.9"  # latest for rust 1.62
 regex-cache = "<=0.1"  # latest for rust 1.62
 serde = "1.0"
 serde_derive = "1.0"
-strum = { version = "0.25", features = ["derive"] }
+strum = { version = "0.16", features = ["derive"] }
 thiserror = "1.0"
 
 [build-dependencies]
 bincode = "1.3"
-quick-xml = "0.30"
+quick-xml = "0.24"
 regex = "<=1.9"  # latest for rust 1.62
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-doc-comment = "0.3"
+doc-comment = "0.1"
 rstest = "0.18"
 rstest_reuse = "0.6"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "phonenumber"
 version = "0.3.3+8.13.9"
 edition = "2021"
-rust-version = "1.65"  # because of regex 1.7
+rust-version = "1.62"  # because of Sailfish OS
 
 authors = ["Gabriel Féron <g@leirbag.net>", "Ruben De Smet <ruben.de.smet@rubdos.be>", "meh. <meh@1aim.com>"]
 license = "Apache-2.0"
@@ -16,12 +16,12 @@ readme = "README.md"
 bincode = "1.3"
 either = "1.9"
 fnv = "1.0"
-itertools = ">=0.10, <=0.11"
+itertools = "0.11"
 nom = "7.1"
 once_cell = "1.18.0"
 quick-xml = "0.30"
-regex = "1.7"
-regex-cache = "0.2"
+regex = "<=1.9"  # latest for rust 1.62
+regex-cache = "<=0.1"  # latest for rust 1.62
 serde = "1.0"
 serde_derive = "1.0"
 strum = { version = "0.25", features = ["derive"] }
@@ -30,7 +30,7 @@ thiserror = "1.0"
 [build-dependencies]
 bincode = "1.3"
 quick-xml = "0.30"
-regex = "1.7"
+regex = "<=1.9"  # latest for rust 1.62
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "phonenumber"
 version = "0.3.3+8.13.9"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.65"  # because of regex 1.7
 
 authors = ["Gabriel Féron <g@leirbag.net>", "Ruben De Smet <ruben.de.smet@rubdos.be>", "meh. <meh@1aim.com>"]
 license = "Apache-2.0"
@@ -14,22 +14,22 @@ readme = "README.md"
 
 [dependencies]
 bincode = "1.3"
-either = "1.8"
+either = "1.9"
 fnv = "1.0"
 itertools = ">=0.10, <=0.11"
-lazy_static = "1.4"
 nom = "7.1"
-quick-xml = "0.28"
+once_cell = "1.18.0"
+quick-xml = "0.30"
 regex = "1.7"
 regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1.0"
 
 [build-dependencies]
 bincode = "1.3"
-quick-xml = "0.28"
+quick-xml = "0.30"
 regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"
@@ -37,6 +37,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 doc-comment = "0.3"
-rstest = "0.17"
-rstest_reuse = "0.5"
+rstest = "0.18"
+rstest_reuse = "0.6"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "phonenumber"
 version = "0.3.3+8.13.9"
 edition = "2021"
-rust-version = "1.62"  # because of Sailfish OS
+rust-version = "1.58.0"
 
 authors = ["Gabriel Féron <g@leirbag.net>", "Ruben De Smet <ruben.de.smet@rubdos.be>", "meh. <meh@1aim.com>"]
 license = "Apache-2.0"
@@ -14,29 +14,29 @@ readme = "README.md"
 
 [dependencies]
 bincode = "1.3"
-either = "1.0"
+either = "1.8"
 fnv = "1.0"
-itertools = "0.2"
-nom = "7.0"
+itertools = ">=0.10, <= 0.12"
+nom = "7.1"
 once_cell = "1.0"
-quick-xml = "0.24"
-regex = "<=1.9"  # latest for rust 1.62
-regex-cache = "<=0.1"  # latest for rust 1.62
+quick-xml = ">=0.28, <= 0.31"
+regex = "1.7"
+regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-strum = { version = "0.16", features = ["derive"] }
+strum = { version = ">=0.24, <=0.25", features = ["derive"] }
 thiserror = "1.0"
 
 [build-dependencies]
 bincode = "1.3"
-quick-xml = "0.24"
-regex = "<=1.9"  # latest for rust 1.62
+quick-xml = ">=0.28, <=0.31"
+regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-doc-comment = "0.1"
-rstest = "0.18"
+doc-comment = "0.3"
+rstest = ">= 0.13, <=0.18"
 rstest_reuse = "0.6"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Rust version of [libphonenumber](https://github.com/googlei18n/libphonenumber).
+We currently require 1.58.0 as minimum supported Rust version (MSRV).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ phonenumber = "0.3"
 The following example parses, validates and formats the given phone number.
 
 ```rust,no_run
-extern crate phonenumber;
-
 use phonenumber::Mode;
 use std::env;
 

--- a/build.rs
+++ b/build.rs
@@ -4,13 +4,6 @@ use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 extern crate quick_xml as xml;
-extern crate regex;
-extern crate thiserror;
-
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
 
 use bincode::Options;
 

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,6 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
-extern crate quick_xml as xml;
-
 use bincode::Options;
 
 #[path = "src/metadata/loader.rs"]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-extern crate phonenumber;
 use phonenumber::Mode;
 
 fn main() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.65"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.65"

--- a/src/carrier.rs
+++ b/src/carrier.rs
@@ -40,7 +40,7 @@ impl AsRef<str> for Carrier {
 }
 
 impl fmt::Display for Carrier {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/carrier.rs
+++ b/src/carrier.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,6 +16,7 @@
 
 use fnv::{FnvHashMap, FnvHashSet};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
 
 /// The minimum length of the National Significant Number.
@@ -47,330 +48,334 @@ pub const RFC3966_ISDN_SUBADDRESS: &str = ";isub=";
 
 pub const REGION_CODE_FOR_NON_GEO_ENTITY: &str = "001";
 
-lazy_static! {
-    /// Map of country calling codes that use a mobile token before the area code. One example of when
-    /// this is relevant is when determining the length of the national destination code, which should
-    /// be the length of the area code plus the length of the mobile token.
-    pub static ref MOBILE_TOKEN_MAPPINGS: FnvHashMap<u16, &'static str> = {
-        let mut map = FnvHashMap::default();
-        map.insert(52, "1");
-        map.insert(54, "9");
-        map
-    };
+/// Map of country calling codes that use a mobile token before the area code. One example of when
+/// this is relevant is when determining the length of the national destination code, which should
+/// be the length of the area code plus the length of the mobile token.
+pub static MOBILE_TOKEN_MAPPINGS: Lazy<FnvHashMap<u16, &'static str>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
+    map.insert(52, "1");
+    map.insert(54, "9");
+    map
+});
 
-    /// Set of country codes that have geographically assigned mobile numbers
-    /// (see GEO_MOBILE_COUNTRIES below) which are not based on *area codes*. For
-    /// example, in China mobile numbers start with a carrier indicator, and
-    /// beyond that are geographically assigned: this carrier indicator is not
-    /// considered to be an area code.
-    pub static ref GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES: FnvHashSet<u16> = {
+/// Set of country codes that have geographically assigned mobile numbers
+/// (see GEO_MOBILE_COUNTRIES below) which are not based on *area codes*. For
+/// example, in China mobile numbers start with a carrier indicator, and
+/// beyond that are geographically assigned: this carrier indicator is not
+/// considered to be an area code.
+pub static GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES: Lazy<FnvHashSet<u16>> =
+    Lazy::new(|| {
         let mut set = FnvHashSet::default();
         set.insert(86); // China
         set
-    };
+    });
 
-    /// Set of country calling codes that have geographically assigned mobile
-    /// numbers. This may not be complete; we add calling codes case by case, as
-    /// we find geographical mobile numbers or hear from user reports. Note that
-    /// countries like the US, where we can't distinguish between fixed-line or
-    /// mobile numbers, are not listed here, since we consider
-    /// FIXED_LINE_OR_MOBILE to be a possibly geographically-related type anyway
-    /// (like FIXED_LINE).
-    pub static ref GEO_MOBILE_COUNTRIES: FnvHashSet<u16> = {
-        let mut set = FnvHashSet::default();
-        set.insert(52); // Mexico
-        set.insert(54); // Argentina
-        set.insert(55); // Brazil
-        set.insert(62); // Indonesia: some prefixes only (fixed CMDA wireless)
-        set.extend(GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES.iter());
-        set
-    };
+/// Set of country calling codes that have geographically assigned mobile
+/// numbers. This may not be complete; we add calling codes case by case, as
+/// we find geographical mobile numbers or hear from user reports. Note that
+/// countries like the US, where we can't distinguish between fixed-line or
+/// mobile numbers, are not listed here, since we consider
+/// FIXED_LINE_OR_MOBILE to be a possibly geographically-related type anyway
+/// (like FIXED_LINE).
+pub static GEO_MOBILE_COUNTRIES: Lazy<FnvHashSet<u16>> = Lazy::new(|| {
+    let mut set = FnvHashSet::default();
+    set.insert(52); // Mexico
+    set.insert(54); // Argentina
+    set.insert(55); // Brazil
+    set.insert(62); // Indonesia: some prefixes only (fixed CMDA wireless)
+    set.extend(GEO_MOBILE_COUNTRIES_WITHOUT_MOBILE_AREA_CODES.iter());
+    set
+});
 
-    /// Helper ASCII mappings.
-    pub static ref ASCII_MAPPINGS: FnvHashMap<char, char> = {
-        let mut map = FnvHashMap::default();
-        map.insert('0', '0');
-        map.insert('1', '1');
-        map.insert('2', '2');
-        map.insert('3', '3');
-        map.insert('4', '4');
-        map.insert('5', '5');
-        map.insert('6', '6');
-        map.insert('7', '7');
-        map.insert('8', '8');
-        map.insert('9', '9');
-        map
-    };
+/// Helper ASCII mappings.
+pub static ASCII_MAPPINGS: Lazy<FnvHashMap<char, char>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
+    map.insert('0', '0');
+    map.insert('1', '1');
+    map.insert('2', '2');
+    map.insert('3', '3');
+    map.insert('4', '4');
+    map.insert('5', '5');
+    map.insert('6', '6');
+    map.insert('7', '7');
+    map.insert('8', '8');
+    map.insert('9', '9');
+    map
+});
 
-    /// A map that contains characters that are essential when dialling. That
-    /// means any of the characters in this map must not be removed from a number
-    /// when dialling, otherwise the call will not reach the intended
-    /// destination.
-    pub static ref DIALLABLE_CHAR_MAPPINGS: FnvHashMap<char, char> = {
-        let mut map = FnvHashMap::default();
-        map.extend(ASCII_MAPPINGS.iter());
-        map.insert(PLUS_SIGN, PLUS_SIGN);
-        map.insert(STAR_SIGN, STAR_SIGN);
-        map.insert(SHARP_SIGN, SHARP_SIGN);
-        map
-    };
+/// A map that contains characters that are essential when dialling. That
+/// means any of the characters in this map must not be removed from a number
+/// when dialling, otherwise the call will not reach the intended
+/// destination.
+pub static DIALLABLE_CHAR_MAPPINGS: Lazy<FnvHashMap<char, char>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
+    map.extend(ASCII_MAPPINGS.iter());
+    map.insert(PLUS_SIGN, PLUS_SIGN);
+    map.insert(STAR_SIGN, STAR_SIGN);
+    map.insert(SHARP_SIGN, SHARP_SIGN);
+    map
+});
 
-    /// Only upper-case variants of alpha characters are stored.
-  pub static ref ALPHA_MAPPINGS: FnvHashMap<char, char> = {
-        let mut map = FnvHashMap::default();
-        map.insert('A', '2');
-        map.insert('B', '2');
-        map.insert('C', '2');
-        map.insert('D', '3');
-        map.insert('E', '3');
-        map.insert('F', '3');
-        map.insert('G', '4');
-        map.insert('H', '4');
-        map.insert('I', '4');
-        map.insert('J', '5');
-        map.insert('K', '5');
-        map.insert('L', '5');
-        map.insert('M', '6');
-        map.insert('N', '6');
-        map.insert('O', '6');
-        map.insert('P', '7');
-        map.insert('Q', '7');
-        map.insert('R', '7');
-        map.insert('S', '7');
-        map.insert('T', '8');
-        map.insert('U', '8');
-        map.insert('V', '8');
-        map.insert('W', '9');
-        map.insert('X', '9');
-        map.insert('Y', '9');
-        map.insert('Z', '9');
+/// Only upper-case variants of alpha characters are stored.
+pub static ALPHA_MAPPINGS: Lazy<FnvHashMap<char, char>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
+    map.insert('A', '2');
+    map.insert('B', '2');
+    map.insert('C', '2');
+    map.insert('D', '3');
+    map.insert('E', '3');
+    map.insert('F', '3');
+    map.insert('G', '4');
+    map.insert('H', '4');
+    map.insert('I', '4');
+    map.insert('J', '5');
+    map.insert('K', '5');
+    map.insert('L', '5');
+    map.insert('M', '6');
+    map.insert('N', '6');
+    map.insert('O', '6');
+    map.insert('P', '7');
+    map.insert('Q', '7');
+    map.insert('R', '7');
+    map.insert('S', '7');
+    map.insert('T', '8');
+    map.insert('U', '8');
+    map.insert('V', '8');
+    map.insert('W', '9');
+    map.insert('X', '9');
+    map.insert('Y', '9');
+    map.insert('Z', '9');
 
-        map.insert('a', '2');
-        map.insert('b', '2');
-        map.insert('c', '2');
-        map.insert('d', '3');
-        map.insert('e', '3');
-        map.insert('f', '3');
-        map.insert('g', '4');
-        map.insert('h', '4');
-        map.insert('i', '4');
-        map.insert('j', '5');
-        map.insert('k', '5');
-        map.insert('l', '5');
-        map.insert('m', '6');
-        map.insert('n', '6');
-        map.insert('o', '6');
-        map.insert('p', '7');
-        map.insert('q', '7');
-        map.insert('r', '7');
-        map.insert('s', '7');
-        map.insert('t', '8');
-        map.insert('u', '8');
-        map.insert('v', '8');
-        map.insert('w', '9');
-        map.insert('x', '9');
-        map.insert('y', '9');
-        map.insert('z', '9');
+    map.insert('a', '2');
+    map.insert('b', '2');
+    map.insert('c', '2');
+    map.insert('d', '3');
+    map.insert('e', '3');
+    map.insert('f', '3');
+    map.insert('g', '4');
+    map.insert('h', '4');
+    map.insert('i', '4');
+    map.insert('j', '5');
+    map.insert('k', '5');
+    map.insert('l', '5');
+    map.insert('m', '6');
+    map.insert('n', '6');
+    map.insert('o', '6');
+    map.insert('p', '7');
+    map.insert('q', '7');
+    map.insert('r', '7');
+    map.insert('s', '7');
+    map.insert('t', '8');
+    map.insert('u', '8');
+    map.insert('v', '8');
+    map.insert('w', '9');
+    map.insert('x', '9');
+    map.insert('y', '9');
+    map.insert('z', '9');
 
-        map
-    };
+    map
+});
 
-  /// For performance reasons, amalgamate both into one map.
-    pub static ref ALPHA_PHONE_MAPPINGS: FnvHashMap<char, char> = {
-        let mut map = FnvHashMap::default();
-        map.extend(ASCII_MAPPINGS.iter());
-        map.extend(ALPHA_MAPPINGS.iter());
-        map
-    };
+/// For performance reasons, amalgamate both into one map.
+pub static ALPHA_PHONE_MAPPINGS: Lazy<FnvHashMap<char, char>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
+    map.extend(ASCII_MAPPINGS.iter());
+    map.extend(ALPHA_MAPPINGS.iter());
+    map
+});
 
-  /// Separate map of all symbols that we wish to retain when formatting alpha
-    /// numbers. This includes digits, ASCII letters and number grouping symbols
-    /// such as "-" and " ".
-    pub static ref ALL_PLUS_NUMBER_GROUPING_SYMBOLS: FnvHashMap<char, char> = {
-        let mut map = FnvHashMap::default();
+/// Separate map of all symbols that we wish to retain when formatting alpha
+/// numbers. This includes digits, ASCII letters and number grouping symbols
+/// such as "-" and " ".
+pub static ALL_PLUS_NUMBER_GROUPING_SYMBOLS: Lazy<FnvHashMap<char, char>> = Lazy::new(|| {
+    let mut map = FnvHashMap::default();
 
-        for &c in ALPHA_MAPPINGS.keys() {
-            map.insert(c, c);
-            map.insert(c.to_lowercase().next().unwrap(), c);
-        }
+    for &c in ALPHA_MAPPINGS.keys() {
+        map.insert(c, c);
+        map.insert(c.to_lowercase().next().unwrap(), c);
+    }
 
-        map.extend(ASCII_MAPPINGS.iter());
+    map.extend(ASCII_MAPPINGS.iter());
 
-        map.insert('-',        '-');
-        map.insert('\u{FF0D}', '-');
-        map.insert('\u{2010}', '-');
-        map.insert('\u{2011}', '-');
-        map.insert('\u{2012}', '-');
-        map.insert('\u{2013}', '-');
-        map.insert('\u{2014}', '-');
-        map.insert('\u{2015}', '-');
-        map.insert('\u{2212}', '-');
-        map.insert('/',        '/');
-        map.insert('\u{FF0F}', '/');
-        map.insert(' ',        ' ');
-        map.insert('\u{3000}', ' ');
-        map.insert('\u{2060}', ' ');
-        map.insert('.',        '.');
-        map.insert('\u{FF0E}', '.');
+    map.insert('-', '-');
+    map.insert('\u{FF0D}', '-');
+    map.insert('\u{2010}', '-');
+    map.insert('\u{2011}', '-');
+    map.insert('\u{2012}', '-');
+    map.insert('\u{2013}', '-');
+    map.insert('\u{2014}', '-');
+    map.insert('\u{2015}', '-');
+    map.insert('\u{2212}', '-');
+    map.insert('/', '/');
+    map.insert('\u{FF0F}', '/');
+    map.insert(' ', ' ');
+    map.insert('\u{3000}', ' ');
+    map.insert('\u{2060}', ' ');
+    map.insert('.', '.');
+    map.insert('\u{FF0E}', '.');
 
-        map
-    };
+    map
+});
 
-    /// Pattern that makes it easy to distinguish whether a region has a unique
-    /// international dialing prefix or not. If a region has a unique
-    /// international prefix (e.g. 011 in USA), it will be represented as a
-    /// string that contains a sequence of ASCII digits. If there are multiple
-    /// available international prefixes in a region, they will be represented as
-    /// a regex string that always contains character(s) other than ASCII digits.
-    ///
-    /// Note this regex also includes tilde, which signals waiting for the tone.
-    pub static ref UNIQUE_INTERNATIONAL_PREFIX: Regex =
-        Regex::new(r"[\d]+(?:[~\x{2053}\x{223C}\x{FF5E}][\d]+)?").unwrap();
+/// Pattern that makes it easy to distinguish whether a region has a unique
+/// international dialing prefix or not. If a region has a unique
+/// international prefix (e.g. 011 in USA), it will be represented as a
+/// string that contains a sequence of ASCII digits. If there are multiple
+/// available international prefixes in a region, they will be represented as
+/// a regex string that always contains character(s) other than ASCII digits.
+///
+/// Note this regex also includes tilde, which signals waiting for the tone.
+pub static UNIQUE_INTERNATIONAL_PREFIX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[\d]+(?:[~\x{2053}\x{223C}\x{FF5E}][\d]+)?").unwrap());
 
-    /// Regular expression of acceptable punctuation found in phone numbers. This
-    /// excludes punctuation found as a leading character only.
-    ///
-    /// This consists of dash characters, white space characters, full stops,
-    /// slashes, square brackets, parentheses and tildes. It also includes the
-    /// letter 'x' as that is found as a placeholder for carrier information in
-    /// some phone numbers. Full-width variants are also present.
-    pub static ref VALID_PUNCTUATION: String =
-        String::from(r"-x\x{2010}-\x{2015}\x{2212}\x{30FC}\x{FF0D}-\x{FF0F} \x{00A0}\x{00AD}\x{200B}\x{2060}\x{3000}()\x{FF08}\x{FF09}\x{FF3B}\x{FF3D}.\[\]/~\x{2053}\x{223C}\x{FF5E}");
+/// Regular expression of acceptable punctuation found in phone numbers. This
+/// excludes punctuation found as a leading character only.
+///
+/// This consists of dash characters, white space characters, full stops,
+/// slashes, square brackets, parentheses and tildes. It also includes the
+/// letter 'x' as that is found as a placeholder for carrier information in
+/// some phone numbers. Full-width variants are also present.
+pub const VALID_PUNCTUATION: &str = r"-x\x{2010}-\x{2015}\x{2212}\x{30FC}\x{FF0D}-\x{FF0F} \x{00A0}\x{00AD}\x{200B}\x{2060}\x{3000}()\x{FF08}\x{FF09}\x{FF3B}\x{FF3D}.\[\]/~\x{2053}\x{223C}\x{FF5E}";
 
-    /// Pattern for digits.
-    pub static ref DIGITS: String = String::from(r"\p{Nd}");
+/// Pattern for digits.
+pub const DIGITS: &str = r"\p{Nd}";
 
-    /// Plus characters.
-    pub static ref PLUS_CHARS: String = String::from(r"\+\x{FF0B}");
+/// Plus characters.
+pub const PLUS_CHARS: &str = r"\+\x{FF0B}";
 
-    /// We accept alpha characters in phone numbers, ASCII only, upper and lower
-    /// case.
-    pub static ref VALID_ALPHA: String = {
-        let mut string = String::new();
-        let     clean  = Regex::new(r"[, \[\]]").unwrap();
-        let     alpha  = ALPHA_MAPPINGS.keys().join("");
+/// We accept alpha characters in phone numbers, ASCII only, upper and lower
+/// case.
+pub static VALID_ALPHA: Lazy<String> = Lazy::new(|| {
+    let mut string = String::new();
+    let clean = Regex::new(r"[, \[\]]").unwrap();
+    let alpha = ALPHA_MAPPINGS.keys().join("");
 
-        string.push_str(&clean.replace(&alpha, ""));
-        string.push_str(&clean.replace(&alpha.to_lowercase(), ""));
+    string.push_str(&clean.replace(&alpha, ""));
+    string.push_str(&clean.replace(&alpha.to_lowercase(), ""));
 
-        string
-    };
+    string
+});
 
-    pub static ref PLUS_CHARS_PATTERN: Regex =
-        Regex::new(&format!("[{}]+", *PLUS_CHARS)).unwrap();
+pub static PLUS_CHARS_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(&format!("[{}]+", PLUS_CHARS)).unwrap());
 
-    pub static ref SEPARATOR_PATTERN: Regex =
-        Regex::new(&format!("[{}]+", *VALID_PUNCTUATION)).unwrap();
+pub static SEPARATOR_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(&format!("[{}]+", VALID_PUNCTUATION)).unwrap());
 
-    pub static ref CAPTURING_DIGIT: Regex =
-        Regex::new(&format!("({})", *DIGITS)).unwrap();
+pub static CAPTURING_DIGIT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(&format!("({})", DIGITS)).unwrap());
 
-    /// Regular expression of acceptable characters that may start a phone number
-    /// for the purposes of parsing. This allows us to strip away meaningless
-    /// prefixes to phone numbers that may be mistakenly given to us. This
-    /// consists of digits, the plus symbol and arabic-indic digits. This does
-    /// not contain alpha characters, although they may be used later in the
-    /// number. It also does not include other punctuation, as this will be
-    /// stripped later during parsing and is of no information value when parsing
-    /// a number.
-  pub static ref VALID_START_CHAR: Regex =
-        Regex::new(&format!("[{}{}]", *PLUS_CHARS, *DIGITS)).unwrap();
+/// Regular expression of acceptable characters that may start a phone number
+/// for the purposes of parsing. This allows us to strip away meaningless
+/// prefixes to phone numbers that may be mistakenly given to us. This
+/// consists of digits, the plus symbol and arabic-indic digits. This does
+/// not contain alpha characters, although they may be used later in the
+/// number. It also does not include other punctuation, as this will be
+/// stripped later during parsing and is of no information value when parsing
+/// a number.
+pub static VALID_START_CHAR: Lazy<Regex> =
+    Lazy::new(|| Regex::new(&format!("[{}{}]", PLUS_CHARS, DIGITS)).unwrap());
 
-    /// Regular expression of characters typically used to start a second phone
-    /// number for the purposes of parsing. This allows us to strip off parts of
-    /// the number that are actually the start of another number, such as for:
-    /// (530) 583-6985 x302/x2303 -> the second extension here makes this
-    /// actually two phone numbers, (530) 583-6985 x302 and (530) 583-6985 x2303.
-    /// We remove the second extension so that the first number is parsed
-    /// correctly.
-    pub static ref SECOND_NUMBER_START: Regex =
-        Regex::new(r"[\\/] *x").unwrap();
+/// Regular expression of characters typically used to start a second phone
+/// number for the purposes of parsing. This allows us to strip off parts of
+/// the number that are actually the start of another number, such as for:
+/// (530) 583-6985 x302/x2303 -> the second extension here makes this
+/// actually two phone numbers, (530) 583-6985 x302 and (530) 583-6985 x2303.
+/// We remove the second extension so that the first number is parsed
+/// correctly.
+pub static SECOND_NUMBER_START: Lazy<Regex> = Lazy::new(|| Regex::new(r"[\\/] *x").unwrap());
 
-    /// Regular expression of trailing characters that we want to remove. We
-    /// remove all characters that are not alpha or numerical characters. The
-    /// hash character is retained here, as it may signify the previous block was
-    /// an extension.
-    pub static ref UNWANTED_END_CHARS: Regex =
-        Regex::new(r"[[\P{N}&&\P{L}]&&[^#]]+$").unwrap();
+/// Regular expression of trailing characters that we want to remove. We
+/// remove all characters that are not alpha or numerical characters. The
+/// hash character is retained here, as it may signify the previous block was
+/// an extension.
+pub static UNWANTED_END_CHARS: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[[\P{N}&&\P{L}]&&[^#]]+$").unwrap());
 
-    /// We use this pattern to check if the phone number has at least three
-    /// letters in it - if so, then we treat it as a number where some
-    /// phone-number digits are represented by letters.
-  pub static ref VALID_ALPHA_PHONE: Regex =
-        Regex::new(r"(?:.*?[A-Za-z]){3}.*").unwrap();
+/// We use this pattern to check if the phone number has at least three
+/// letters in it - if so, then we treat it as a number where some
+/// phone-number digits are represented by letters.
+pub static VALID_ALPHA_PHONE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:.*?[A-Za-z]){3}.*").unwrap());
 
-    /// Default extension prefix to use when formatting. This will be put in
-    /// front of any extension component of the number, after the main national
-    /// number is formatted. For example, if you wish the default extension
-    /// formatting to be " extn: 3456", then you should specify " extn: " here as
-    /// the default extension prefix. This can be overridden by region-specific
-    /// preferences.
-  pub static ref DEFAULT_EXTN_PREFIX: String = String::from(" ext. ");
+/// Default extension prefix to use when formatting. This will be put in
+/// front of any extension component of the number, after the main national
+/// number is formatted. For example, if you wish the default extension
+/// formatting to be " extn: 3456", then you should specify " extn: " here as
+/// the default extension prefix. This can be overridden by region-specific
+/// preferences.
+pub const DEFAULT_EXTN_PREFIX: &str = " ext. ";
 
-    /// Pattern to capture digits used in an extension. Places a maximum length
-    /// of "7" for an extension.
-  pub static ref CAPTURING_EXTN_DIGITS: String = format!("({}{{0,7}})", *DIGITS);
+/// Pattern to capture digits used in an extension. Places a maximum length
+/// of "7" for an extension.
+pub static CAPTURING_EXTN_DIGITS: Lazy<String> = Lazy::new(|| format!("({}{{0,7}})", DIGITS));
 
-    /// Regexp of all possible ways to write extensions, for use when parsing.
-    /// This will be run as a case-insensitive regexp match. Wide character
-    /// versions are also provided after each ASCII version.
-    ///
-    /// For parsing, we are slightly more lenient in our interpretation than for
-    /// matching. Here we allow "comma" and "semicolon" as possible extension
-    /// indicators. When matching, these are hardly ever used to indicate this.
-    pub static ref EXTN_PATTERNS_FOR_PARSING: String =
-        format!(r"{rfc3966_extn_prefix}{capturing_extn_digits}|[ \x{{00A0}}\t,]*(?:e?xt(?:ensi(?:o\x{{0301}}?|\x{{00F3}}))?n?|\x{{FF45}}?\x{{FF58}}\x{{FF54}}\x{{FF4E}}?|[{symbols}]|int|anexo|\x{{FF49}}\x{{FF4E}}\x{{FF54}})[:\.\x{{FF0E}}]?[ \x{{00A0}}\t,-]*{capturing_extn_digits}#?|[- ]+({digits}{{1,5}})#",
-            rfc3966_extn_prefix = RFC3966_EXTN_PREFIX,
-            capturing_extn_digits = *CAPTURING_EXTN_DIGITS,
-            symbols = r",;x\x{FF58}#\x{FF03}~\x{FF5E}",
-            digits = *DIGITS);
+/// Regexp of all possible ways to write extensions, for use when parsing.
+/// This will be run as a case-insensitive regexp match. Wide character
+/// versions are also provided after each ASCII version.
+///
+/// For parsing, we are slightly more lenient in our interpretation than for
+/// matching. Here we allow "comma" and "semicolon" as possible extension
+/// indicators. When matching, these are hardly ever used to indicate this.
+pub static EXTN_PATTERNS_FOR_PARSING: Lazy<String> = Lazy::new(|| {
+    format!(
+        r"{rfc3966_extn_prefix}{capturing_extn_digits}|[ \x{{00A0}}\t,]*(?:e?xt(?:ensi(?:o\x{{0301}}?|\x{{00F3}}))?n?|\x{{FF45}}?\x{{FF58}}\x{{FF54}}\x{{FF4E}}?|[{symbols}]|int|anexo|\x{{FF49}}\x{{FF4E}}\x{{FF54}})[:\.\x{{FF0E}}]?[ \x{{00A0}}\t,-]*{capturing_extn_digits}#?|[- ]+({digits}{{1,5}})#",
+        rfc3966_extn_prefix = RFC3966_EXTN_PREFIX,
+        capturing_extn_digits = *CAPTURING_EXTN_DIGITS,
+        symbols = r",;x\x{FF58}#\x{FF03}~\x{FF5E}",
+        digits = DIGITS
+    )
+});
 
-    /// Regexp of all possible ways to write extensions, for use when parsing.
-    /// This will be run as a case-insensitive regexp match. Wide character
-    /// versions are also provided after each ASCII version.
-    ///
-    /// One-character symbols that can be used to indicate an extension.
-    pub static ref EXTN_PATTERNS_FOR_MATCHING: String =
-        format!(r"{rfc3966_extn_prefix}{capturing_extn_digits}|[ \x{{00A0}}\t,]*(?:e?xt(?:ensi(?:o\x{{0301}}?|\x{{00F3}}))?n?|\x{{FF45}}?\x{{FF58}}\x{{FF54}}\x{{FF4E}}?|[{symbols}]|int|anexo|\x{{FF49}}\x{{FF4E}}\x{{FF54}})[:\.\x{{FF0E}}]?[ \x{{00A0}}\t,-]*{capturing_extn_digits}#?|[- ]+({digits}{{1,5}})#",
-            rfc3966_extn_prefix = RFC3966_EXTN_PREFIX,
-            capturing_extn_digits = *CAPTURING_EXTN_DIGITS,
-            symbols = r"x\x{FF58}#\x{FF03}~\x{FF5E}",
-            digits = *DIGITS);
+/// Regexp of all possible ways to write extensions, for use when parsing.
+/// This will be run as a case-insensitive regexp match. Wide character
+/// versions are also provided after each ASCII version.
+///
+/// One-character symbols that can be used to indicate an extension.
+pub static EXTN_PATTERNS_FOR_MATCHING: Lazy<String> = Lazy::new(|| {
+    format!(
+        r"{rfc3966_extn_prefix}{capturing_extn_digits}|[ \x{{00A0}}\t,]*(?:e?xt(?:ensi(?:o\x{{0301}}?|\x{{00F3}}))?n?|\x{{FF45}}?\x{{FF58}}\x{{FF54}}\x{{FF4E}}?|[{symbols}]|int|anexo|\x{{FF49}}\x{{FF4E}}\x{{FF54}})[:\.\x{{FF0E}}]?[ \x{{00A0}}\t,-]*{capturing_extn_digits}#?|[- ]+({digits}{{1,5}})#",
+        rfc3966_extn_prefix = RFC3966_EXTN_PREFIX,
+        capturing_extn_digits = *CAPTURING_EXTN_DIGITS,
+        symbols = r"x\x{FF58}#\x{FF03}~\x{FF5E}",
+        digits = DIGITS
+    )
+});
 
-    /// Regexp of all known extension prefixes used by different regions followed
-    /// by 1 or more valid digits, for use when parsing.
-  pub static ref EXTN_PATTERN: Regex =
-        RegexBuilder::new(&format!(r"(?:{})$", *EXTN_PATTERNS_FOR_PARSING))
-            .case_insensitive(true)
-            .build()
-            .unwrap();
+/// Regexp of all known extension prefixes used by different regions followed
+/// by 1 or more valid digits, for use when parsing.
+pub static EXTN_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new(&format!(r"(?:{})$", *EXTN_PATTERNS_FOR_PARSING))
+        .case_insensitive(true)
+        .build()
+        .unwrap()
+});
 
-    /// We append optionally the extension pattern to the end here, as a valid
-    /// phone number may have an extension prefix appended, followed by 1 or more
-    /// digits.
-  pub static ref VALID_PHONE_NUMBER: Regex =
-        RegexBuilder::new(&format!(r"(?:{})?", *EXTN_PATTERNS_FOR_PARSING))
-            .case_insensitive(true)
-            .build()
-            .unwrap();
+/// We append optionally the extension pattern to the end here, as a valid
+/// phone number may have an extension prefix appended, followed by 1 or more
+/// digits.
+pub static VALID_PHONE_NUMBER: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new(&format!(r"(?:{})?", *EXTN_PATTERNS_FOR_PARSING))
+        .case_insensitive(true)
+        .build()
+        .unwrap()
+});
 
-  pub static ref NON_DIGITS: Regex =
-        Regex::new(r"(\D+)").unwrap();
+pub static NON_DIGITS: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\D+)").unwrap());
 
-    /// The FIRST_GROUP_PATTERN was originally set to $1 but there are some
-    /// countries for which the first group is not used in the national pattern
-    /// (e.g. Argentina) so the $1 group does not match correctly.  Therefore, we
-    /// use \d, so that the first group actually used in the pattern will be
-    /// matched.
-  pub static ref FIRST_GROUP: Regex = Regex::new(r"(\$\d)").unwrap();
-  pub static ref NP:          &'static str = "$NP";
-  pub static ref FG:          &'static str = "$FG";
-  pub static ref CC:          &'static str = "$CC";
+/// The FIRST_GROUP_PATTERN was originally set to $1 but there are some
+/// countries for which the first group is not used in the national pattern
+/// (e.g. Argentina) so the $1 group does not match correctly.  Therefore, we
+/// use \d, so that the first group actually used in the pattern will be
+/// matched.
+pub static FIRST_GROUP: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\$\d)").unwrap());
 
-    /// A pattern that is used to determine if the national prefix formatting
-    /// rule has the first group only, i.e., does not start with the national
-    /// prefix. Note that the pattern explicitly allows for unbalanced
-    /// parentheses.
-  pub static ref FIRST_GROUP_ONLY_PREFIX: Regex =
-        Regex::new(r"\(?\$1\)?").unwrap();
-}
+pub const NP: &str = "$NP";
+pub const FG: &str = "$FG";
+pub const CC: &str = "$CC";
+
+/// A pattern that is used to determine if the national prefix formatting
+/// rule has the first group only, i.e., does not start with the national
+/// prefix. Note that the pattern explicitly allows for unbalanced
+/// parentheses.
+pub static FIRST_GROUP_ONLY_PREFIX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\(?\$1\)?").unwrap());

--- a/src/country.rs
+++ b/src/country.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Needed because of re-export of Id::*
+#![allow(unused_qualifications)]
+
 //! Country related types.
 
 use strum::{AsRefStr, EnumString};

--- a/src/country.rs
+++ b/src/country.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Needed because of re-export of Id::*
-#![allow(unused_qualifications)]
-
 //! Country related types.
 
 use serde_derive::{Deserialize, Serialize};
@@ -326,4 +323,4 @@ pub enum Id {
     ZW,
 }
 
-pub use self::Id::*;
+pub use Id::*;

--- a/src/country.rs
+++ b/src/country.rs
@@ -32,7 +32,7 @@ pub struct Code {
 
 /// The source from which the country code is derived. This is not set in the
 /// general parsing method, but in the method that parses and keeps raw_input.
-#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Source {
     /// The country code is derived based on a phone number with a leading "+",
@@ -54,13 +54,8 @@ pub enum Source {
     /// format (without country code). For example, this would be set when
     /// parsing the French number "01 42 68 53 00", when the default country is
     /// supplied as France.
+    #[default]
     Default,
-}
-
-impl Default for Source {
-    fn default() -> Self {
-        Source::Default
-    }
 }
 
 impl Code {

--- a/src/country.rs
+++ b/src/country.rs
@@ -29,7 +29,7 @@ pub struct Code {
 
 /// The source from which the country code is derived. This is not set in the
 /// general parsing method, but in the method that parses and keeps raw_input.
-#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash, Debug, Default)]
+#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Source {
     /// The country code is derived based on a phone number with a leading "+",
@@ -51,8 +51,13 @@ pub enum Source {
     /// format (without country code). For example, this would be set when
     /// parsing the French number "01 42 68 53 00", when the default country is
     /// supplied as France.
-    #[default]
     Default,
+}
+
+impl Default for Source {
+    fn default() -> Self {
+        Source::Default
+    }
 }
 
 impl Code {

--- a/src/country.rs
+++ b/src/country.rs
@@ -17,9 +17,9 @@
 
 //! Country related types.
 
-use strum::{AsRefStr, EnumString};
-
+use serde_derive::{Deserialize, Serialize};
 use std::str;
+use strum::{AsRefStr, EnumString};
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub struct Code {

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,7 +91,7 @@ pub enum Parse {
 pub enum LoadMetadata {
     /// Parsing XML failed, the XML is malformed.
     #[error("Malformed Metadata XML: {0}")]
-    Xml(#[from] xml::Error),
+    Xml(#[from] quick_xml::Error),
 
     /// Parsing UTF-8 string from XML failed.
     #[error("Non UTF-8 string in Metadata XML: {0}")]

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -40,7 +40,7 @@ impl AsRef<str> for Extension {
 }
 
 impl fmt::Display for Extension {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -98,7 +98,7 @@ pub fn format_with<'d, 'n>(
 }
 
 impl<'n, 'd, 'f> fmt::Display for Formatter<'n, 'd, 'f> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let db = self.database.unwrap_or(&DATABASE);
 
         // If the country code is invalid, return an error.
@@ -247,9 +247,9 @@ fn replace(
                     .get(1)
                     .unwrap()
                     .as_str();
-                let format = transform.replace(*consts::NP, meta.national_prefix().unwrap_or(""));
-                let format = format.replace(*consts::FG, &format!("${}", first));
-                let format = format.replace(*consts::CC, carrier.unwrap_or(""));
+                let format = transform.replace(consts::NP, meta.national_prefix().unwrap_or(""));
+                let format = format.replace(consts::FG, &format!("${}", first));
+                let format = format.replace(consts::CC, carrier.unwrap_or(""));
 
                 consts::FIRST_GROUP.replace(formatter.format(), &*format)
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,23 +14,10 @@
 
 #![recursion_limit = "1024"]
 
-#[macro_use]
-extern crate lazy_static;
-
-extern crate nom;
-extern crate thiserror;
-
-extern crate either;
-extern crate fnv;
-extern crate itertools;
 extern crate quick_xml as xml;
-extern crate regex;
-extern crate regex_cache;
 
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate bincode;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 #![recursion_limit = "1024"]
 
 #[cfg(test)]
-use rstest_reuse;
+use doc_comment::doctest;
 
 #[cfg(test)]
-use doc_comment::doctest;
+use rstest_reuse;
 
 #[cfg(test)]
 doctest!("../README.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,11 @@
 
 #![recursion_limit = "1024"]
 
-extern crate quick_xml as xml;
-
-#[macro_use]
-extern crate serde_derive;
-
-#[cfg(test)]
-#[macro_use]
-extern crate doc_comment;
-
 #[cfg(test)]
 use rstest_reuse;
+
+#[cfg(test)]
+use doc_comment::doctest;
 
 #[cfg(test)]
 doctest!("../README.md");

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -12,22 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error;
+use crate::metadata::loader;
+use bincode;
+use bincode::Options;
+use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
+use regex_cache::{CachedRegex, CachedRegexBuilder, RegexCache};
 use std::borrow::Borrow;
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufReader, Cursor};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-
-use once_cell::sync::Lazy;
-
-use bincode;
-use bincode::Options;
-use fnv::FnvHashMap;
-use regex_cache::{CachedRegex, CachedRegexBuilder, RegexCache};
-
-use crate::error;
-use crate::metadata::loader;
 
 const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -19,6 +19,8 @@ use std::io::{BufReader, Cursor};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use once_cell::sync::Lazy;
+
 use bincode;
 use bincode::Options;
 use fnv::FnvHashMap;
@@ -29,12 +31,16 @@ use crate::metadata::loader;
 
 const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 
-lazy_static! {
-    /// The Google provided metadata database, used as default.
-    pub static ref DEFAULT: Database =
-        Database::from(bincode::options()
-        .with_varint_encoding().deserialize(DATABASE).unwrap()).unwrap();
-}
+/// The Google provided metadata database, used as default.
+pub static DEFAULT: Lazy<Database> = Lazy::new(|| {
+    Database::from(
+        bincode::options()
+            .with_varint_encoding()
+            .deserialize(DATABASE)
+            .unwrap(),
+    )
+    .unwrap()
+});
 
 /// Representation of a database of metadata for phone number.
 #[derive(Clone, Debug)]

--- a/src/metadata/loader.rs
+++ b/src/metadata/loader.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error;
+use quick_xml::events::attributes::Attribute;
+use quick_xml::events::{self, Event};
+use quick_xml::Reader;
+use serde_derive::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::str;
-
-use crate::xml::events::attributes::Attribute;
-use crate::xml::events::{self, Event};
-use crate::xml::Reader;
-
-use crate::error;
-use serde_derive::{Deserialize, Serialize};
 
 /// Temporary defaults for `Format` and `Descriptor`.
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
@@ -177,7 +175,7 @@ fn territory<R: BufRead>(
     let mut meta = Metadata::default();
 
     for attr in e.attributes() {
-        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+        let Attribute { key, value } = attr.map_err(quick_xml::Error::InvalidAttr)?;
 
         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
             ("id", value) => meta.id = Some(value.into()),
@@ -362,7 +360,8 @@ fn descriptor<R: BufRead>(
             Event::Empty(ref e) => match e.name().into_inner() {
                 b"possibleLengths" => {
                     for attr in e.attributes() {
-                        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+                        let Attribute { key, value } =
+                            attr.map_err(quick_xml::Error::InvalidAttr)?;
 
                         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
                             ("national", value) => descriptor.possible_length = lengths(value)?,
@@ -483,7 +482,7 @@ fn format<R: BufRead>(
     let mut international = None;
 
     for attr in e.attributes() {
-        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+        let Attribute { key, value } = attr.map_err(quick_xml::Error::InvalidAttr)?;
 
         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
             ("pattern", value) => format.pattern = Some(value.into()),

--- a/src/metadata/loader.rs
+++ b/src/metadata/loader.rs
@@ -20,6 +20,7 @@ use crate::xml::events::{self, Event};
 use crate::xml::Reader;
 
 use crate::error;
+use serde_derive::{Deserialize, Serialize};
 
 /// Temporary defaults for `Format` and `Descriptor`.
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]

--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -57,7 +57,7 @@ impl From<NationalNumber> for u64 {
 }
 
 impl fmt::Display for NationalNumber {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for _ in 0..self.zeros {
             write!(f, "0")?;
         }

--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 /// The national number part of a phone number.

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -311,7 +311,9 @@ pub fn national_number<'a>(meta: &Metadata, mut number: Number<'a>) -> Number<'a
 
         number.national = trim(number.national, end);
     } else if let Some(transform) = transform {
-        let transformed = parsing.replace(&number.national, transform).into_owned();
+        let transformed = parsing
+            .replace(&number.national, transform.as_str())
+            .into_owned();
 
         if viable && !meta.descriptors.general.is_match(&transformed) {
             return number;

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::consts;
+use crate::country;
+use crate::error;
+use crate::metadata::{Database, Metadata};
+use crate::phone_number::Type;
+use crate::validator;
+use fnv::FnvHashMap;
 use nom::{
     self,
     character::complete::*,
@@ -20,17 +27,8 @@ use nom::{
     multi::*,
     AsChar, IResult,
 };
-use std::borrow::Cow;
-
-use fnv::FnvHashMap;
 use regex_cache::CachedRegex;
-
-use crate::consts;
-use crate::country;
-use crate::error;
-use crate::metadata::{Database, Metadata};
-use crate::phone_number::Type;
-use crate::validator;
+use std::borrow::Cow;
 
 macro_rules! parse {
 	($input:ident => ) => ();

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -370,7 +370,7 @@ pub fn normalize<'a>(mut number: Number<'a>, mappings: &FnvHashMap<char, char>) 
     number
 }
 
-pub fn trim(value: Cow<str>, start: usize) -> Cow<str> {
+pub fn trim(value: Cow<'_, str>, start: usize) -> Cow<'_, str> {
     match value {
         Cow::Borrowed(value) => Cow::Borrowed(&value[start..]),
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -44,7 +44,7 @@ pub fn parse_with<S: AsRef<str>>(
     country: Option<country::Id>,
     string: S,
 ) -> Result<PhoneNumber, error::Parse> {
-    fn phone_number(i: &str) -> IResult<&str, helper::Number> {
+    fn phone_number(i: &str) -> IResult<&str, helper::Number<'_>> {
         parse! { i => alt((rfc3966::phone_number, natural::phone_number)) }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,7 +21,6 @@ use crate::metadata::{Database, DATABASE};
 use crate::national_number::NationalNumber;
 use crate::phone_number::{PhoneNumber, Type};
 use crate::validator::{self, Validation};
-
 use nom::{branch::alt, IResult};
 
 #[macro_use]

--- a/src/parser/natural.rs
+++ b/src/parser/natural.rs
@@ -18,7 +18,7 @@ use nom::IResult;
 use crate::consts;
 use crate::parser::helper::*;
 
-pub fn phone_number(i: &str) -> IResult<&str, Number> {
+pub fn phone_number(i: &str) -> IResult<&str, Number<'_>> {
     let (_, i) = extract(i)?;
     let extension = consts::EXTN_PATTERN.captures(i);
 

--- a/src/parser/natural.rs
+++ b/src/parser/natural.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nom::error::ErrorKind;
-use nom::IResult;
-
 use crate::consts;
 use crate::parser::helper::*;
+use nom::error::ErrorKind;
+use nom::IResult;
 
 pub fn phone_number(i: &str) -> IResult<&str, Number<'_>> {
     let (_, i) = extract(i)?;

--- a/src/parser/rfc3966.rs
+++ b/src/parser/rfc3966.rs
@@ -25,7 +25,7 @@ use nom::{
 
 use crate::parser::helper::*;
 
-pub fn phone_number(i: &str) -> IResult<&str, Number> {
+pub fn phone_number(i: &str) -> IResult<&str, Number<'_>> {
     parse! { i =>
         opt(tag_no_case("Tel:"));
         let prefix = opt(prefix);
@@ -169,6 +169,6 @@ mod test {
     #[test]
     fn advisory_1() {
         // Just make sure this does not panic.
-        let _ = rfc3966::phone_number(".;phone-context=");
+        rfc3966::phone_number(".;phone-context=").unwrap();
     }
 }

--- a/src/parser/rfc3966.rs
+++ b/src/parser/rfc3966.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::parser::helper::*;
 use fnv::FnvHashMap;
 use nom::{
     self,
@@ -22,8 +23,6 @@ use nom::{
     multi::*,
     AsChar, IResult,
 };
-
-use crate::parser::helper::*;
 
 pub fn phone_number(i: &str) -> IResult<&str, Number<'_>> {
     parse! { i =>

--- a/src/parser/rfc3966.rs
+++ b/src/parser/rfc3966.rs
@@ -168,6 +168,6 @@ mod test {
     #[test]
     fn advisory_1() {
         // Just make sure this does not panic.
-        rfc3966::phone_number(".;phone-context=").unwrap();
+        drop(rfc3966::phone_number(".;phone-context="));
     }
 }

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use either::*;
-use std::fmt;
-use std::ops::Deref;
-use std::str::FromStr;
-
 use crate::carrier::Carrier;
 use crate::country;
 use crate::error;
@@ -26,6 +21,11 @@ use crate::metadata::{Database, Metadata, DATABASE};
 use crate::national_number::NationalNumber;
 use crate::parser;
 use crate::validator;
+use either::*;
+use serde_derive::{Deserialize, Serialize};
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
 
 /// A phone number.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -148,14 +148,14 @@ impl FromStr for PhoneNumber {
 }
 
 impl fmt::Display for PhoneNumber {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.format())
     }
 }
 
 impl PhoneNumber {
     /// Get information about the country for the phone number.
-    pub fn country(&self) -> Country {
+    pub fn country(&self) -> Country<'_> {
         Country(self)
     }
 
@@ -251,7 +251,7 @@ impl<'a> Deref for Country<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::country::{self, *};
+    use crate::country::{self, Id::*};
     use crate::metadata::DATABASE;
     use crate::Type;
     use crate::{parser, Mode, PhoneNumber};

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -106,7 +106,7 @@ pub fn is_valid_with(database: &Database, number: &PhoneNumber) -> bool {
         .unwrap_or(false)
 }
 
-pub fn length(meta: &Metadata, number: &ParseNumber, kind: Type) -> Validation {
+pub fn length(meta: &Metadata, number: &ParseNumber<'_>, kind: Type) -> Validation {
     let desc = if let Some(desc) = meta.descriptors().get(kind) {
         desc
     } else {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use either::*;
-
 use crate::consts;
 use crate::country;
 use crate::metadata::{Database, Metadata, DATABASE};
 use crate::parser;
 use crate::parser::helper::Number as ParseNumber;
 use crate::phone_number::{PhoneNumber, Type};
+use either::*;
 
 /// Possible outcomes when testing if a `PhoneNumber` is possible.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
Main reason for this PR is to bump `strum` to 0.25 so we can get rid of the syn 1.x dependency and move to syn 2.x

While working on it and running tests, `cargo fmt` and `cargo clippy` had several remarks, so I followed those as well

Most notably `lazy_static!` has been replaced with `once_cell` as preferred by clippy