### PR TITLE
Rm `thiserror` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 strum = { version = "0.24", features = ["derive"] }
-thiserror = "1.0"
 
 [build-dependencies]
 bincode = "1.3"
@@ -33,7 +32,6 @@ quick-xml = "0.28"
 regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"
-thiserror = "1.0"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 extern crate quick_xml as xml;
 extern crate regex;
-extern crate thiserror;
 
 extern crate serde;
 #[macro_use]

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,30 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use thiserror::Error;
+use core::fmt;
+use std::error::Error;
 
 /// Metadata loading errors.
-#[derive(Error, Clone, Debug)]
+#[derive(Debug)]
 pub enum Metadata {
     /// EOF was reached before the parsing was complete.
-    #[error("unexpected end of file")]
     UnexpectedEof,
 
     /// A mismatched tag was met.
-    #[error("mismatched tag: {0:?}")]
     MismatchedTag(String),
 
     /// A required value was missing.
-    #[error("{phase}: missing value: {name:?}")]
     #[allow(unused)] // This is unused in the build script
     MissingValue { phase: String, name: String },
 
     /// An element was not handled.
-    #[error("{phase}: unhandled element: {name:?}")]
     UnhandledElement { phase: String, name: String },
 
     /// An attribute was not handled.
-    #[error("{phase}: unhandled attribute: {name:?}={value:?}")]
     UnhandledAttribute {
         phase: String,
         name: String,
@@ -43,77 +39,163 @@ pub enum Metadata {
     },
 
     /// An event was not handled.
-    #[error("{phase}: unhandled event: {event:?}")]
     UnhandledEvent { phase: String, event: String },
 }
 
+impl Error for Metadata {}
+
+impl fmt::Display for Metadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Metadata::UnexpectedEof => f.write_str("unexpected end of file"),
+            Metadata::MismatchedTag(s) => write!(f, "mismatched tag: {s:?}"),
+            Metadata::MissingValue { phase, name } => write!(f, "{phase}: missing value: {name:?}"),
+            Metadata::UnhandledElement { phase, name } => {
+                write!(f, "{phase}: unhandled element: {name:?}")
+            }
+            Metadata::UnhandledAttribute { phase, name, value } => {
+                write!(f, "{phase}: unhandled attribute: {name:?}={value:?}")
+            }
+            Metadata::UnhandledEvent { phase, event } => {
+                write!(f, "{phase}: unhandled event: {event:?}")
+            }
+        }
+    }
+}
+
 /// Parsing errors.
-#[derive(Error, Clone, Debug)]
+#[derive(Debug)]
 pub enum Parse {
     /// This generally indicates the string passed in had less than 3 digits in
     /// it.
-    #[error("not a number")]
     #[allow(unused)] // This is unused in the build script
     NoNumber,
 
     /// The country code supplied did not belong to a supported country or
     /// non-geographical entity.
-    #[error("invalid country code")]
     #[allow(unused)] // This is unused in the build script
     InvalidCountryCode,
 
     /// This indicates the string started with an international dialing prefix,
     /// but after this was stripped from the number, had less digits than any
     /// valid phone number (including country code) could have.
-    #[error("the number is too short after IDD")]
     #[allow(unused)] // This is unused in the build script
     TooShortAfterIdd,
 
     /// This indicates the string, after any country code has been stripped, had
     /// less digits than any valid phone number could have.
-    #[error("the number is too short after the country code")]
     #[allow(unused)] // This is unused in the build script
     TooShortNsn,
 
     /// This indicates the string had more digits than any valid phone number
     /// could have.
-    #[error("the number is too long")]
     #[allow(unused)] // This is unused in the build script
     TooLong,
 
     /// A integer parts of a number is malformed, normally this should be caught by the parsing regexes.
-    #[error("malformed integer part in phone number: {0}")]
-    MalformedInteger(#[from] std::num::ParseIntError),
+    MalformedInteger(std::num::ParseIntError),
+}
+
+impl Error for Parse {}
+
+impl fmt::Display for Parse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Parse::NoNumber => f.write_str("not a number"),
+            Parse::InvalidCountryCode => f.write_str("invalid country code"),
+            Parse::TooShortAfterIdd => f.write_str("the number is too short after IDD"),
+            Parse::TooShortNsn => f.write_str("the number is too short after the country code"),
+            Parse::TooLong => f.write_str("the number is too long"),
+            Parse::MalformedInteger(e) => write!(f, "malformed integer part in phone number: {e}"),
+        }
+    }
+}
+
+impl From<std::num::ParseIntError> for Parse {
+    fn from(e: std::num::ParseIntError) -> Self {
+        Parse::MalformedInteger(e)
+    }
 }
 
 /// Loading of Database) Error
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum LoadMetadata {
     /// Parsing XML failed, the XML is malformed.
-    #[error("Malformed Metadata XML: {0}")]
-    Xml(#[from] xml::Error),
+    Xml(xml::Error),
 
     /// Parsing UTF-8 string from XML failed.
-    #[error("Non UTF-8 string in Metadata XML: {0}")]
-    Utf8(#[from] std::str::Utf8Error),
+    Utf8(std::str::Utf8Error),
 
     /// Metadata Error
-    #[error("{0}")]
-    Metadata(#[from] Metadata),
+    Metadata(Metadata),
 
     /// Malformed integer in Metadata XML database
-    #[error("Malformed integer in Metadata XML: {0}")]
-    Integer(#[from] std::num::ParseIntError),
+    Integer(std::num::ParseIntError),
 
     /// Malformed boolean in Metadata XML database
-    #[error("Malformed boolean in Metadata XML: {0}")]
-    Bool(#[from] std::str::ParseBoolError),
+    Bool(std::str::ParseBoolError),
 
     /// I/O-Error while reading Metadata XML database
-    #[error("I/O-Error in Metadata XML: {0}")]
-    Io(#[from] std::io::Error),
+    Io(std::io::Error),
 
     /// Malformed Regex in Metadata XML database
-    #[error("Malformed Regex: {0}")]
-    Regex(#[from] regex::Error),
+    Regex(regex::Error),
+}
+
+impl Error for LoadMetadata {}
+
+impl fmt::Display for LoadMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LoadMetadata::Xml(e) => write!(f, "Malformed Metadata XML: {e}"),
+            LoadMetadata::Utf8(e) => write!(f, "Non UTF-8 string in Metadata XML: {e}"),
+            LoadMetadata::Metadata(e) => write!(f, "{e}"),
+            LoadMetadata::Integer(e) => write!(f, "Malformed integer in Metadata XML: {e}"),
+            LoadMetadata::Bool(e) => write!(f, "Malformed boolean in Metadata XML: {e}"),
+            LoadMetadata::Io(e) => write!(f, "I/O-Error in Metadata XML: {e}"),
+            LoadMetadata::Regex(e) => write!(f, "Malformed Regex: {e}"),
+        }
+    }
+}
+
+impl From<xml::Error> for LoadMetadata {
+    fn from(e: xml::Error) -> Self {
+        LoadMetadata::Xml(e)
+    }
+}
+
+impl From<std::str::Utf8Error> for LoadMetadata {
+    fn from(e: std::str::Utf8Error) -> Self {
+        LoadMetadata::Utf8(e)
+    }
+}
+
+impl From<Metadata> for LoadMetadata {
+    fn from(e: Metadata) -> Self {
+        LoadMetadata::Metadata(e)
+    }
+}
+
+impl From<std::num::ParseIntError> for LoadMetadata {
+    fn from(e: std::num::ParseIntError) -> Self {
+        LoadMetadata::Integer(e)
+    }
+}
+
+impl From<std::str::ParseBoolError> for LoadMetadata {
+    fn from(e: std::str::ParseBoolError) -> Self {
+        LoadMetadata::Bool(e)
+    }
+}
+
+impl From<std::io::Error> for LoadMetadata {
+    fn from(e: std::io::Error) -> Self {
+        LoadMetadata::Io(e)
+    }
+}
+
+impl From<regex::Error> for LoadMetadata {
+    fn from(e: regex::Error) -> Self {
+        LoadMetadata::Regex(e)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 extern crate lazy_static;
 
 extern crate nom;
-extern crate thiserror;
 
 extern crate either;
 extern crate fnv;


### PR DESCRIPTION
Including `thiserror` in a lib forces the users of the lib to build `thiserror` and it's dependencies. Namely `proc-macro2`, `quote` and `syn`.

These dependencies will more than likely be included through another dependecy path, but given that there are only three Error types (one only for build.rs) and the expansion of the Error definitions are simple, it's better to drop `thiserror` in favor of keeping the dependecy set as small as possible.