### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,14 @@ jobs:
       matrix:
         toolchain: ["stable", "beta"]
         coverage: [false]
+        tests: [true]
         include:
           - toolchain: "nightly"
             coverage: true
+            tests: true
+          - toolchain: "1.58.0"
+            coverage: false
+            tests: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -39,22 +44,30 @@ jobs:
       - name: Configure CI cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Build
+      - name: Build all targets
         uses: actions-rs/cargo@v1
+        if: ${{ matrix.tests }}
         with:
           command: build
           args: --all-targets
 
+      - name: Build
+        uses: actions-rs/cargo@v1
+        if: ${{ !matrix.tests }}
+        with:
+          command: build
+          args: --lib --all-features
+
       - name: Run tests
         uses: actions-rs/cargo@v1
-        if: ${{ !matrix.coverage }}
+        if: ${{ !matrix.coverage && matrix.tests }}
         with:
           command: test
           args: --all-targets --no-fail-fast
 
       - name: Run tests
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.coverage }}
+        if: ${{ matrix.coverage && matrix.tests }}
         with:
           command: test
           args: --all-targets --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ readme = "README.md"
 bincode = "1.3"
 either = "1.8"
 fnv = "1.0"
-itertools = ">=0.10, <=0.11"
 lazy_static = "1.4"
+itertools = ">=0.10, <= 0.12"
 nom = "7.1"
-quick-xml = "0.28"
+quick-xml = ">=0.28, <= 0.31"
 regex = "1.7"
 regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = ">=0.24, <=0.25", features = ["derive"] }
 thiserror = "1.0"
 
 [build-dependencies]
 bincode = "1.3"
-quick-xml = "0.28"
+quick-xml = ">=0.28, <=0.31"
 regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"
@@ -37,6 +37,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 doc-comment = "0.3"
-rstest = "0.17"
-rstest_reuse = "0.5"
+rstest = ">= 0.13, <=0.18"
+rstest_reuse = "0.6"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Rust version of [libphonenumber](https://github.com/googlei18n/libphonenumber).
+We currently require 1.58.0 as minimum supported Rust version (MSRV).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ phonenumber = "0.3"
 The following example parses, validates and formats the given phone number.
 
 ```rust,no_run
-extern crate phonenumber;
-
 use phonenumber::Mode;
 use std::env;
 

--- a/build.rs
+++ b/build.rs
@@ -3,15 +3,6 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
-extern crate quick_xml as xml;
-extern crate regex;
-extern crate thiserror;
-
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
-
 use bincode::Options;
 
 #[path = "src/metadata/loader.rs"]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-extern crate phonenumber;
 use phonenumber::Mode;
 
 fn main() {

--- a/src/carrier.rs
+++ b/src/carrier.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -47,7 +47,7 @@ pub const RFC3966_ISDN_SUBADDRESS: &str = ";isub=";
 
 pub const REGION_CODE_FOR_NON_GEO_ENTITY: &str = "001";
 
-lazy_static! {
+lazy_static::lazy_static! {
     /// Map of country calling codes that use a mobile token before the area code. One example of when
     /// this is relevant is when determining the length of the national destination code, which should
     /// be the length of the area code plus the length of the mobile token.

--- a/src/country.rs
+++ b/src/country.rs
@@ -14,9 +14,9 @@
 
 //! Country related types.
 
-use strum::{AsRefStr, EnumString};
-
+use serde_derive::{Deserialize, Serialize};
 use std::str;
+use strum::{AsRefStr, EnumString};
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub struct Code {

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,7 +91,7 @@ pub enum Parse {
 pub enum LoadMetadata {
     /// Parsing XML failed, the XML is malformed.
     #[error("Malformed Metadata XML: {0}")]
-    Xml(#[from] xml::Error),
+    Xml(#[from] quick_xml::Error),
 
     /// Parsing UTF-8 string from XML failed.
     #[error("Non UTF-8 string in Metadata XML: {0}")]

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,27 +14,8 @@
 
 #![recursion_limit = "1024"]
 
-#[macro_use]
-extern crate lazy_static;
-
-extern crate nom;
-extern crate thiserror;
-
-extern crate either;
-extern crate fnv;
-extern crate itertools;
-extern crate quick_xml as xml;
-extern crate regex;
-extern crate regex_cache;
-
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
-
 #[cfg(test)]
-#[macro_use]
-extern crate doc_comment;
+use doc_comment::doctest;
 
 #[cfg(test)]
 use rstest_reuse;

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -29,7 +29,7 @@ use crate::metadata::loader;
 
 const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 
-lazy_static! {
+lazy_static::lazy_static! {
     /// The Google provided metadata database, used as default.
     pub static ref DEFAULT: Database =
         Database::from(bincode::options()

--- a/src/metadata/loader.rs
+++ b/src/metadata/loader.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error;
+use quick_xml::events::attributes::Attribute;
+use quick_xml::events::{self, Event};
+use quick_xml::Reader;
+use serde_derive::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::str;
-
-use crate::xml::events::attributes::Attribute;
-use crate::xml::events::{self, Event};
-use crate::xml::Reader;
-
-use crate::error;
 
 /// Temporary defaults for `Format` and `Descriptor`.
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
@@ -176,7 +175,7 @@ fn territory<R: BufRead>(
     let mut meta = Metadata::default();
 
     for attr in e.attributes() {
-        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+        let Attribute { key, value } = attr.map_err(quick_xml::Error::InvalidAttr)?;
 
         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
             ("id", value) => meta.id = Some(value.into()),
@@ -361,7 +360,8 @@ fn descriptor<R: BufRead>(
             Event::Empty(ref e) => match e.name().into_inner() {
                 b"possibleLengths" => {
                     for attr in e.attributes() {
-                        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+                        let Attribute { key, value } =
+                            attr.map_err(quick_xml::Error::InvalidAttr)?;
 
                         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
                             ("national", value) => descriptor.possible_length = lengths(value)?,
@@ -482,7 +482,7 @@ fn format<R: BufRead>(
     let mut international = None;
 
     for attr in e.attributes() {
-        let Attribute { key, value } = attr.map_err(xml::Error::InvalidAttr)?;
+        let Attribute { key, value } = attr.map_err(quick_xml::Error::InvalidAttr)?;
 
         match (str::from_utf8(key.into_inner())?, str::from_utf8(&value)?) {
             ("pattern", value) => format.pattern = Some(value.into()),

--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 /// The national number part of a phone number.

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use either::*;
-use std::fmt;
-use std::ops::Deref;
-use std::str::FromStr;
-
 use crate::carrier::Carrier;
 use crate::country;
 use crate::error;
@@ -26,6 +21,11 @@ use crate::metadata::{Database, Metadata, DATABASE};
 use crate::national_number::NationalNumber;
 use crate::parser;
 use crate::validator;
+use either::*;
+use serde_derive::{Deserialize, Serialize};
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
 
 /// A phone number.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]


### PR DESCRIPTION
Follow-up from #60, such that #60 can focus on the `lazy_static` -> `OnceCell` transition.