### PR TITLE
refactor: Replace bincode with postcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["phonenumber", "phone", "number", "parser", "formatter"]
 readme = "README.md"
 
 [dependencies]
-bincode = "1.3"
 either = "1.11"
 fnv = "1"
 once_cell = "1"
 nom = "7.1"
+postcard = "1.1"
 quick-xml = ">=0.28, <= 0.38"
 regex = "1.7"
 regex-cache = "0.2"
@@ -27,7 +27,7 @@ strum = { version = ">=0.24, <=0.27", features = ["derive"] }
 thiserror = "2.0"
 
 [build-dependencies]
-bincode = "1.3"
+postcard = { version = "1.1", features = ["use-std"] }
 quick-xml = ">=0.28, <=0.38"
 regex = "1.7"
 serde = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,6 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
-use bincode::Options;
-
 #[path = "src/metadata/loader.rs"]
 mod loader;
 
@@ -24,8 +22,5 @@ fn main() {
             .expect("could not create database file"),
     );
 
-    bincode::options()
-        .with_varint_encoding()
-        .serialize_into(&mut out, &metadata)
-        .expect("failed to serialize database");
+    postcard::to_io(&metadata, &mut out).expect("failed to serialize database");
 }

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -15,8 +15,6 @@
 use crate::error;
 use crate::metadata::loader;
 use crate::Metadata;
-use bincode;
-use bincode::Options;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
 use regex_cache::{CachedRegex, CachedRegexBuilder, RegexCache};
@@ -30,15 +28,8 @@ use std::sync::{Arc, Mutex};
 const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 
 /// The Google provided metadata database, used as default.
-pub static DEFAULT: Lazy<Database> = Lazy::new(|| {
-    Database::from(
-        bincode::options()
-            .with_varint_encoding()
-            .deserialize(DATABASE)
-            .unwrap(),
-    )
-    .unwrap()
-});
+pub static DEFAULT: Lazy<Database> =
+    Lazy::new(|| Database::from(postcard::from_bytes(DATABASE).unwrap()).unwrap());
 
 /// Representation of a database of metadata for phone number.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I saw #98 and figured I would take a crack at moving away from `bincode`. I went with `postcard` as the replacement, as it is essentially a drop-in replacement for `bincode` given how `phonenumber` used it. `postcard` also uses [varint encoding by default](https://docs.rs/postcard/1.1.3/postcard/index.html#variable-length-data), which is a nice plus. 

The only major difference (from what I can tell) is that the serialized format is different from bincode, but that shouldn't matter.